### PR TITLE
Capture pre-overlay pane geometry

### DIFF
--- a/.ish/herdr-pluck-50oj--handle-overlaysource-pane-geometry-mismatch.md
+++ b/.ish/herdr-pluck-50oj--handle-overlaysource-pane-geometry-mismatch.md
@@ -1,0 +1,93 @@
+---
+# herdr-pluck-50oj
+title: Handle overlay/source pane geometry mismatch
+status: completed
+type: task
+priority: high
+tags:
+- pluck
+- herdr
+- geometry
+created_at: 2026-06-19T17:03:11.933956Z
+updated_at: 2026-06-19T17:35:10.023481Z
+parent: herdr-pluck-t3sf
+blocking:
+- herdr-pluck-vhdh
+- herdr-pluck-z4cv
+- herdr-pluck-guwf
+blocked_by:
+- herdr-pluck-jyye
+---
+
+## Context
+Herdr overlay panes are implemented by splitting the active pane, focusing the plugin pane, and zooming the tab. Pane rendering frames terminals when the underlying layout has multiple panes, and Herdr reserves a stable one-column scrollbar gutter from terminal content when possible.
+
+This means the picker cannot safely use post-overlay `pane.layout` dimensions for the source pane, and cannot assume the overlay terminal size equals the source pane's visible terminal size:
+
+- A single source pane is unframed before launch, but the overlay is framed after launch, so the overlay content area is smaller and offset by the border.
+- An unzoomed split source pane is framed inside its split rect, but the overlay is zoomed to the full tab, so the overlay pane is much larger than the source pane.
+- A zoomed source pane in a multi-pane tab is framed before launch, so it most closely matches the overlay geometry.
+
+## Work
+- In action mode, before opening the overlay, capture a frozen pre-overlay geometry snapshot for the target pane.
+- Derive effective source terminal content rect from Herdr layout semantics: use full terminal area when the tab is zoomed to the focused target, otherwise the target pane's layout rect; inset by one-cell borders only when the underlying pane count is greater than one; reserve Herdr's stable scrollbar gutter by subtracting one content column when width permits.
+- Pass this frozen geometry to picker mode via an explicit environment variable, alongside the target pane id.
+- Do not let picker mode recompute source geometry from post-overlay layout, because opening the overlay mutates the tab layout and zoom state.
+- Have the renderer compose source-screen output into the actual overlay terminal viewport using captured source rect and predicted/actual overlay content rect. Pad or crop so hints appear over the original source pane region where possible.
+- Keep matching/wrapping based on source terminal content width; keep final emission bounded by the overlay terminal size.
+- Add adapter/renderer tests for single-pane unframed source, unzoomed split source, and zoomed multi-pane source.
+
+## Verification
+- Tests demonstrate that source geometry is captured before overlay launch and remains stable after launch.
+- Tests cover derived effective content rects for single pane, split pane, and zoomed multi-pane cases.
+- Renderer tests cover padding/cropping from source rect to overlay viewport.
+
+
+## Implementation Notes
+- Added serializable geometry primitives (`Rect`, `SourceGeometrySnapshot`) to distinguish terminal area, source outer rect, and effective source content rect.
+- `open-overlay` now captures `herdr pane layout --pane <target>` before opening the overlay, derives frozen source geometry, and passes it to picker mode through `HERDR_PLUCK_SOURCE_GEOMETRY_JSON` alongside `HERDR_PLUCK_TARGET_PANE_ID`.
+- Picker placeholder now parses and displays the frozen geometry so manual testing can verify pre-overlay capture behavior.
+- Geometry derivation handles single-pane unframed sources, unzoomed split panes with border inset, zoomed multi-pane tabs using full tab area, and Herdr's one-column right scrollbar gutter.
+- Added renderer composition helpers that place source-sized output into an overlay viewport using frozen source coordinates with padding/cropping.
+- Manual smoke test invoked `rmarganti.herdr-pluck.pluck`; overlay pane `wE:pF` displayed the captured geometry for target pane `wE:pE`.
+
+## Verification Results
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.
+- `cargo build --release` passed.
+- `herdr plugin action invoke rmarganti.herdr-pluck.pluck` succeeded and the placeholder displayed frozen geometry.
+
+
+## Coordinate-Space Follow-up
+- Confirmed Herdr layout rect `x`/`y` values are Herdr-global UI coordinates that include sidebar and tab-bar offsets.
+- Added `Rect::relative_to` plus `SourceGeometrySnapshot::{source_content_rect_in_terminal,source_outer_rect_in_terminal}` so downstream rendering can normalize Herdr-global rects before writing to overlay-local terminal coordinates.
+- Added focused docblocks for new geometry models and geometry transport/derivation helpers.
+- Updated picker placeholder to display both absolute source content geometry and source content normalized to Herdr's terminal area.
+- Added tests proving sidebar/tab-bar offsets normalize away and renderer composition does not add sidebar padding when rects are normalized.
+
+## Coordinate-Space Verification Results
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.
+- `cargo build --release` passed.
+- Manual Herdr invocation displayed `source content in terminal`, e.g. absolute `x=140 y=2` normalized to terminal-local `x=114 y=1` for the right split pane.
+
+
+## Review Follow-up
+- Accepted review feedback that `source_geometry_from_env()` was redundant in `cli.rs` because clap already binds `HERDR_PLUCK_SOURCE_GEOMETRY_JSON` into `source_geometry_json`.
+- Removed the fallback to avoid misleading dead code in the production CLI path.
+
+## Review Follow-up Verification
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.
+
+
+## Docblock Follow-up
+- Added succinct docblocks to the private Herdr `pane layout` response wrapper structs: `LayoutEnvelope` and `LayoutResult`.
+
+## Docblock Follow-up Verification
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::herdr::{HerdrAdapter, HERDR_PLUCK_TARGET_PANE_ID};
+use crate::herdr::{HerdrAdapter, HERDR_PLUCK_SOURCE_GEOMETRY_JSON, HERDR_PLUCK_TARGET_PANE_ID};
 use crate::model::PaneId;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -28,6 +28,10 @@ pub enum Command {
         /// Override the pane to pluck from. Defaults to HERDR_PLUCK_TARGET_PANE_ID.
         #[arg(long, env = HERDR_PLUCK_TARGET_PANE_ID)]
         target_pane: Option<String>,
+
+        /// Frozen pre-overlay source geometry JSON. Defaults to HERDR_PLUCK_SOURCE_GEOMETRY_JSON.
+        #[arg(long, env = HERDR_PLUCK_SOURCE_GEOMETRY_JSON)]
+        source_geometry_json: Option<String>,
     },
 }
 
@@ -45,14 +49,23 @@ pub fn run_with(cli: Cli) -> Result<()> {
                 .or_else(|| adapter.target_pane_from_context())
                 .context("could not determine target pane from --target-pane, HERDR_PANE_ID, HERDR_ACTIVE_PANE_ID, or Herdr context")?;
 
-            adapter.open_picker_overlay(&target)?;
+            let geometry = adapter.capture_source_geometry(&target)?;
+            adapter.open_picker_overlay(&target, &geometry)?;
         }
-        Command::Pick { target_pane } => {
+
+        Command::Pick {
+            target_pane,
+            source_geometry_json,
+        } => {
             let target = target_pane
                 .map(PaneId::new)
                 .context("picker requires --target-pane or HERDR_PLUCK_TARGET_PANE_ID")?;
+            let geometry = source_geometry_json
+                .as_deref()
+                .map(crate::herdr::deserialize_source_geometry)
+                .transpose()?;
 
-            adapter.run_picker_placeholder(&target)?;
+            adapter.run_picker_placeholder(&target, geometry.as_ref())?;
         }
     }
 

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -1,13 +1,15 @@
-use crate::model::PaneId;
+use crate::model::{PaneId, Rect, SourceGeometrySnapshot};
 use anyhow::{anyhow, Context, Result};
 use crossterm::event::{read, Event};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use serde::Deserialize;
 use serde_json::Value;
 use std::env;
 use std::io::{self, Write};
 use std::process::Command;
 
 pub const HERDR_PLUCK_TARGET_PANE_ID: &str = "HERDR_PLUCK_TARGET_PANE_ID";
+pub const HERDR_PLUCK_SOURCE_GEOMETRY_JSON: &str = "HERDR_PLUCK_SOURCE_GEOMETRY_JSON";
 
 #[derive(Debug, Clone)]
 pub struct HerdrAdapter {
@@ -64,11 +66,35 @@ impl HerdrAdapter {
         .map(PaneId::new)
     }
 
-    pub fn open_picker_overlay(&self, target: &PaneId) -> Result<()> {
+    /// Capture source-pane geometry before an overlay is opened. Opening a Herdr overlay changes
+    /// focus, zoom, pane count, and frame geometry, so picker mode must use this frozen snapshot.
+    pub fn capture_source_geometry(&self, target: &PaneId) -> Result<SourceGeometrySnapshot> {
+        let output = Command::new(&self.herdr_bin)
+            .args(["pane", "layout", "--pane", &target.0])
+            .output()
+            .with_context(|| format!("failed to run {} pane layout", self.herdr_bin))?;
+
+        if !output.status.success() {
+            return Err(anyhow!(
+                "Herdr pane layout failed with status {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        parse_layout_snapshot(&output.stdout, target)
+    }
+
+    pub fn open_picker_overlay(
+        &self,
+        target: &PaneId,
+        geometry: &SourceGeometrySnapshot,
+    ) -> Result<()> {
         let plugin_id = self
             .plugin_id
             .as_deref()
             .ok_or_else(|| anyhow!("HERDR_PLUGIN_ID is required to open the plugin pane"))?;
+        let geometry_json = serialize_source_geometry(geometry)?;
 
         let status = Command::new(&self.herdr_bin)
             .args([
@@ -83,6 +109,8 @@ impl HerdrAdapter {
                 "overlay",
                 "--env",
                 &format!("{HERDR_PLUCK_TARGET_PANE_ID}={}", target.0),
+                "--env",
+                &format!("{HERDR_PLUCK_SOURCE_GEOMETRY_JSON}={geometry_json}"),
             ])
             .status()
             .with_context(|| format!("failed to launch {} plugin pane", self.herdr_bin))?;
@@ -94,10 +122,50 @@ impl HerdrAdapter {
         }
     }
 
-    pub fn run_picker_placeholder(&self, target: &PaneId) -> Result<()> {
+    pub fn run_picker_placeholder(
+        &self,
+        target: &PaneId,
+        geometry: Option<&SourceGeometrySnapshot>,
+    ) -> Result<()> {
         println!("Herdr Pluck picker scaffold");
         println!();
         println!("Target pane: {}", target.0);
+        match geometry {
+            Some(geometry) => {
+                println!("Frozen pre-overlay geometry captured:");
+                println!(
+                    "  terminal area: x={} y={} w={} h={}",
+                    geometry.terminal_area.x,
+                    geometry.terminal_area.y,
+                    geometry.terminal_area.width,
+                    geometry.terminal_area.height
+                );
+                println!(
+                    "  source outer:  x={} y={} w={} h={}",
+                    geometry.source_outer_rect.x,
+                    geometry.source_outer_rect.y,
+                    geometry.source_outer_rect.width,
+                    geometry.source_outer_rect.height
+                );
+                println!(
+                    "  source content: x={} y={} w={} h={}",
+                    geometry.source_content_rect.x,
+                    geometry.source_content_rect.y,
+                    geometry.source_content_rect.width,
+                    geometry.source_content_rect.height
+                );
+                let local_content = geometry.source_content_rect_in_terminal();
+                println!(
+                    "  source content in terminal: x={} y={} w={} h={}",
+                    local_content.x, local_content.y, local_content.width, local_content.height
+                );
+                println!(
+                    "  panes={} zoomed={} target_focused={}",
+                    geometry.pane_count, geometry.zoomed, geometry.target_focused
+                );
+            }
+            None => println!("Frozen pre-overlay geometry: unavailable"),
+        }
         println!("Matching, rendering, input, and copy flow are implemented in follow-up ishes.");
         println!();
         print!("Press any key to close...");
@@ -115,6 +183,96 @@ impl HerdrAdapter {
         println!();
         Ok(())
     }
+}
+
+/// Top-level Herdr CLI response wrapper for `pane layout`.
+#[derive(Debug, Clone, Deserialize)]
+struct LayoutEnvelope {
+    result: LayoutResult,
+}
+
+/// `pane layout` response payload containing the layout snapshot.
+#[derive(Debug, Clone, Deserialize)]
+struct LayoutResult {
+    layout: LayoutSnapshot,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LayoutSnapshot {
+    area: Rect,
+    focused_pane_id: Option<String>,
+    panes: Vec<LayoutPane>,
+    #[serde(default)]
+    zoomed: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LayoutPane {
+    #[serde(default)]
+    focused: bool,
+    pane_id: String,
+    rect: Rect,
+}
+
+/// Parses Herdr's `pane layout` CLI response into a frozen source geometry snapshot.
+pub fn parse_layout_snapshot(bytes: &[u8], target: &PaneId) -> Result<SourceGeometrySnapshot> {
+    let envelope: LayoutEnvelope =
+        serde_json::from_slice(bytes).context("invalid pane layout JSON")?;
+    Ok(derive_source_geometry(&envelope.result.layout, target))
+}
+
+/// Derives source-pane content geometry from Herdr-global pre-overlay layout coordinates.
+pub fn derive_source_geometry(layout: &LayoutSnapshot, target: &PaneId) -> SourceGeometrySnapshot {
+    let pane_count = layout.panes.len();
+    let target_pane = layout
+        .panes
+        .iter()
+        .find(|pane| pane.pane_id == target.0)
+        .or_else(|| layout.panes.iter().find(|pane| pane.focused));
+    let target_focused = target_pane
+        .map(|pane| pane.focused)
+        .or_else(|| layout.focused_pane_id.as_ref().map(|id| id == &target.0))
+        .unwrap_or(false);
+
+    let use_full_area = layout.zoomed && target_focused;
+    let source_outer_rect = if use_full_area {
+        layout.area
+    } else {
+        target_pane.map(|pane| pane.rect).unwrap_or(layout.area)
+    };
+
+    let border_inset = u16::from(pane_count > 1);
+    let source_content_rect = source_outer_rect
+        .inset(border_inset)
+        .reserve_right_gutter(u16::from(source_outer_rect.inset(border_inset).width > 1));
+
+    SourceGeometrySnapshot {
+        target_pane_id: target.clone(),
+        terminal_area: layout.area,
+        source_outer_rect,
+        source_content_rect,
+        pane_count,
+        zoomed: layout.zoomed,
+        target_focused,
+    }
+}
+
+/// Serializes source geometry for transport through Herdr plugin pane environment variables.
+pub fn serialize_source_geometry(geometry: &SourceGeometrySnapshot) -> Result<String> {
+    serde_json::to_string(geometry).context("failed to serialize source geometry")
+}
+
+/// Deserializes source geometry passed to picker mode.
+pub fn deserialize_source_geometry(json: &str) -> Result<SourceGeometrySnapshot> {
+    serde_json::from_str(json).context("failed to parse source geometry")
+}
+
+/// Reads picker-mode source geometry from the Herdr Pluck environment variable.
+pub fn source_geometry_from_env() -> Result<Option<SourceGeometrySnapshot>> {
+    env::var(HERDR_PLUCK_SOURCE_GEOMETRY_JSON)
+        .ok()
+        .map(|json| deserialize_source_geometry(&json))
+        .transpose()
 }
 
 struct RawModeGuard;
@@ -195,5 +353,121 @@ mod tests {
             adapter.target_pane_from_context(),
             Some(PaneId::new("pane-flat"))
         );
+    }
+
+    #[test]
+    fn derives_single_pane_unframed_content_from_full_area_with_gutter() {
+        let layout = LayoutSnapshot {
+            area: Rect::new(26, 1, 100, 40),
+            focused_pane_id: Some("p1".to_string()),
+            panes: vec![LayoutPane {
+                focused: true,
+                pane_id: "p1".to_string(),
+                rect: Rect::new(26, 1, 100, 40),
+            }],
+            zoomed: false,
+        };
+
+        let geometry = derive_source_geometry(&layout, &PaneId::new("p1"));
+
+        assert_eq!(geometry.source_outer_rect, Rect::new(26, 1, 100, 40));
+        assert_eq!(geometry.source_content_rect, Rect::new(26, 1, 99, 40));
+        assert_eq!(
+            geometry.source_content_rect_in_terminal(),
+            Rect::new(0, 0, 99, 40)
+        );
+        assert_eq!(geometry.pane_count, 1);
+    }
+
+    #[test]
+    fn derives_unzoomed_split_content_from_pane_rect_with_border_and_gutter() {
+        let layout = LayoutSnapshot {
+            area: Rect::new(0, 0, 200, 60),
+            focused_pane_id: Some("p2".to_string()),
+            panes: vec![
+                LayoutPane {
+                    focused: false,
+                    pane_id: "p1".to_string(),
+                    rect: Rect::new(0, 0, 100, 60),
+                },
+                LayoutPane {
+                    focused: true,
+                    pane_id: "p2".to_string(),
+                    rect: Rect::new(100, 0, 100, 60),
+                },
+            ],
+            zoomed: false,
+        };
+
+        let geometry = derive_source_geometry(&layout, &PaneId::new("p2"));
+
+        assert_eq!(geometry.source_outer_rect, Rect::new(100, 0, 100, 60));
+        assert_eq!(geometry.source_content_rect, Rect::new(101, 1, 97, 58));
+        assert_eq!(
+            geometry.source_content_rect_in_terminal(),
+            Rect::new(101, 1, 97, 58)
+        );
+    }
+
+    #[test]
+    fn derives_zoomed_multi_pane_content_from_full_area_with_border_and_gutter() {
+        let layout = LayoutSnapshot {
+            area: Rect::new(26, 1, 226, 63),
+            focused_pane_id: Some("p2".to_string()),
+            panes: vec![
+                LayoutPane {
+                    focused: false,
+                    pane_id: "p1".to_string(),
+                    rect: Rect::new(26, 1, 113, 63),
+                },
+                LayoutPane {
+                    focused: true,
+                    pane_id: "p2".to_string(),
+                    rect: Rect::new(139, 1, 113, 63),
+                },
+            ],
+            zoomed: true,
+        };
+
+        let geometry = derive_source_geometry(&layout, &PaneId::new("p2"));
+
+        assert_eq!(geometry.source_outer_rect, Rect::new(26, 1, 226, 63));
+        assert_eq!(geometry.source_content_rect, Rect::new(27, 2, 223, 61));
+        assert_eq!(
+            geometry.source_content_rect_in_terminal(),
+            Rect::new(1, 1, 223, 61)
+        );
+    }
+
+    #[test]
+    fn rect_relative_to_removes_global_sidebar_and_tab_offsets() {
+        assert_eq!(
+            Rect::new(26, 1, 225, 63).relative_to(Rect::new(26, 1, 226, 63)),
+            Rect::new(0, 0, 225, 63)
+        );
+    }
+
+    #[test]
+    fn source_geometry_json_round_trips() {
+        let geometry = SourceGeometrySnapshot {
+            target_pane_id: PaneId::new("p1"),
+            terminal_area: Rect::new(0, 0, 80, 24),
+            source_outer_rect: Rect::new(0, 0, 80, 24),
+            source_content_rect: Rect::new(0, 0, 79, 24),
+            pane_count: 1,
+            zoomed: false,
+            target_focused: true,
+        };
+
+        let json = serialize_source_geometry(&geometry).unwrap();
+        assert_eq!(deserialize_source_geometry(&json).unwrap(), geometry);
+    }
+
+    #[test]
+    fn parses_actual_herdr_layout_envelope_shape() {
+        let json = br#"{"id":"cli:pane:layout","result":{"layout":{"area":{"height":63,"width":226,"x":26,"y":1},"focused_pane_id":"wE:p2","panes":[{"focused":false,"pane_id":"wE:p1","rect":{"height":63,"width":113,"x":26,"y":1}},{"focused":true,"pane_id":"wE:p2","rect":{"height":63,"width":113,"x":139,"y":1}}],"splits":[],"tab_id":"wE:t1","workspace_id":"wE","zoomed":true},"type":"pane_layout"}}"#;
+
+        let geometry = parse_layout_snapshot(json, &PaneId::new("wE:p2")).unwrap();
+        assert_eq!(geometry.source_content_rect, Rect::new(27, 2, 223, 61));
     }
 }

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -197,6 +197,7 @@ struct LayoutResult {
     layout: LayoutSnapshot,
 }
 
+/// Herdr tab layout snapshot returned by `pane layout` in Herdr-global coordinates.
 #[derive(Debug, Clone, Deserialize)]
 pub struct LayoutSnapshot {
     area: Rect,
@@ -206,6 +207,7 @@ pub struct LayoutSnapshot {
     zoomed: bool,
 }
 
+/// Pane entry within a Herdr layout snapshot.
 #[derive(Debug, Clone, Deserialize)]
 pub struct LayoutPane {
     #[serde(default)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,6 +15,78 @@ pub struct PaneDimensions {
     pub height: u16,
 }
 
+/// Cell-space rectangle from Herdr layout or overlay rendering coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Rect {
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
+impl Rect {
+    pub fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    /// Returns this rect after removing an equal border on all sides.
+    pub fn inset(self, amount: u16) -> Self {
+        let doubled = amount.saturating_mul(2);
+        Self {
+            x: self.x.saturating_add(amount),
+            y: self.y.saturating_add(amount),
+            width: self.width.saturating_sub(doubled),
+            height: self.height.saturating_sub(doubled),
+        }
+    }
+
+    /// Returns this rect with columns reserved from the right edge.
+    pub fn reserve_right_gutter(self, amount: u16) -> Self {
+        Self {
+            width: self.width.saturating_sub(amount.min(self.width)),
+            ..self
+        }
+    }
+
+    /// Converts this rect from an absolute coordinate space to one relative to `origin`.
+    pub fn relative_to(self, origin: Rect) -> Self {
+        Self {
+            x: self.x.saturating_sub(origin.x),
+            y: self.y.saturating_sub(origin.y),
+            ..self
+        }
+    }
+}
+
+/// Frozen pre-overlay source-pane geometry derived from Herdr-global layout coordinates.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceGeometrySnapshot {
+    pub target_pane_id: PaneId,
+    pub terminal_area: Rect,
+    pub source_outer_rect: Rect,
+    pub source_content_rect: Rect,
+    pub pane_count: usize,
+    pub zoomed: bool,
+    pub target_focused: bool,
+}
+
+impl SourceGeometrySnapshot {
+    /// Source content rect relative to Herdr's terminal area, excluding sidebar/tab-bar offsets.
+    pub fn source_content_rect_in_terminal(&self) -> Rect {
+        self.source_content_rect.relative_to(self.terminal_area)
+    }
+
+    /// Source outer rect relative to Herdr's terminal area, excluding sidebar/tab-bar offsets.
+    pub fn source_outer_rect_in_terminal(&self) -> Rect {
+        self.source_outer_rect.relative_to(self.terminal_area)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaneText {
     pub lines: Vec<String>,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,4 +1,4 @@
-use crate::model::{HintAssignment, RenderLine, RenderSpan, RenderStyle};
+use crate::model::{HintAssignment, Rect, RenderLine, RenderSpan, RenderStyle};
 
 pub fn render_placeholder(assignments: &[HintAssignment]) -> Vec<RenderLine> {
     assignments
@@ -16,6 +16,63 @@ pub fn render_placeholder(assignments: &[HintAssignment]) -> Vec<RenderLine> {
             ],
         })
         .collect()
+}
+
+/// Places source-sized text into an overlay-local viewport, padding or clipping as needed.
+pub fn compose_plain_into_overlay(
+    source_lines: &[String],
+    source_content_rect: Rect,
+    overlay_content_rect: Rect,
+    overlay_size: Rect,
+) -> Vec<String> {
+    let overlay_width = overlay_size.width as usize;
+    let overlay_height = overlay_size.height as usize;
+    let offset_x = source_content_rect.x as i32 - overlay_content_rect.x as i32;
+    let offset_y = source_content_rect.y as i32 - overlay_content_rect.y as i32;
+
+    (0..overlay_height)
+        .map(|overlay_y| {
+            let mut row = vec![' '; overlay_width];
+            let source_y = overlay_y as i32 - offset_y;
+            if source_y >= 0 && source_y < source_lines.len() as i32 {
+                for (source_x, ch) in source_lines[source_y as usize].chars().enumerate() {
+                    let overlay_x = source_x as i32 + offset_x;
+                    if overlay_x >= 0 && overlay_x < overlay_width as i32 {
+                        row[overlay_x as usize] = ch;
+                    }
+                }
+            }
+            row.into_iter().collect()
+        })
+        .collect()
+}
+
+/// Places rendered source lines into an overlay-local viewport, flattening styles temporarily.
+pub fn compose_render_lines_into_overlay(
+    source_lines: &[RenderLine],
+    source_content_rect: Rect,
+    overlay_content_rect: Rect,
+    overlay_size: Rect,
+) -> Vec<RenderLine> {
+    let plain_source: Vec<String> = source_lines.iter().map(flatten_render_line).collect();
+    compose_plain_into_overlay(
+        &plain_source,
+        source_content_rect,
+        overlay_content_rect,
+        overlay_size,
+    )
+    .into_iter()
+    .map(|text| RenderLine {
+        spans: vec![RenderSpan {
+            text,
+            style: RenderStyle::Dim,
+        }],
+    })
+    .collect()
+}
+
+fn flatten_render_line(line: &RenderLine) -> String {
+    line.spans.iter().map(|span| span.text.as_str()).collect()
 }
 
 #[cfg(test)]
@@ -40,5 +97,55 @@ mod tests {
 
         assert_eq!(lines[0].spans[0].style, RenderStyle::Hint);
         assert_eq!(lines[0].spans[1].style, RenderStyle::Match);
+    }
+
+    #[test]
+    fn composition_does_not_add_sidebar_padding_when_rects_are_normalized() {
+        let output = compose_plain_into_overlay(
+            &["abc".to_string()],
+            Rect::new(0, 0, 3, 1),
+            Rect::new(0, 0, 10, 2),
+            Rect::new(0, 0, 10, 2),
+        );
+
+        assert_eq!(output[0], "abc       ");
+    }
+
+    #[test]
+    fn composition_pads_source_to_its_position_in_larger_overlay() {
+        let output = compose_plain_into_overlay(
+            &["abc".to_string()],
+            Rect::new(3, 2, 3, 1),
+            Rect::new(0, 0, 10, 5),
+            Rect::new(0, 0, 10, 5),
+        );
+
+        assert_eq!(output[0], "          ");
+        assert_eq!(output[1], "          ");
+        assert_eq!(output[2], "   abc    ");
+    }
+
+    #[test]
+    fn composition_crops_source_left_and_right_to_overlay_viewport() {
+        let output = compose_plain_into_overlay(
+            &["abcdef".to_string()],
+            Rect::new(0, 0, 6, 1),
+            Rect::new(2, 0, 4, 1),
+            Rect::new(0, 0, 4, 1),
+        );
+
+        assert_eq!(output, vec!["cdef".to_string()]);
+    }
+
+    #[test]
+    fn composition_crops_source_above_overlay_viewport() {
+        let output = compose_plain_into_overlay(
+            &["top".to_string(), "bottom".to_string()],
+            Rect::new(0, 0, 6, 2),
+            Rect::new(0, 1, 6, 1),
+            Rect::new(0, 0, 6, 1),
+        );
+
+        assert_eq!(output, vec!["bottom".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary
- capture source pane geometry before opening the overlay
- pass frozen geometry to picker mode via environment JSON
- normalize Herdr-global layout rects to terminal-local coordinates
- add overlay composition helpers and geometry coverage

## Verification
- cargo fmt --all -- --check
- cargo test --all-features
- cargo clippy --all-targets --all
- manual Herdr plugin invocation displayed frozen and normalized geometry