### PR TITLE
feat: implement fixed-width hint engine

### DIFF
--- a/.ish/herdr-pluck-94xq--implement-fixed-width-hint-engine.md
+++ b/.ish/herdr-pluck-94xq--implement-fixed-width-hint-engine.md
@@ -1,14 +1,14 @@
 ---
 # herdr-pluck-94xq
 title: Implement fixed-width hint engine
-status: todo
+status: completed
 type: task
 priority: high
 tags:
 - pluck
 - hints
 created_at: 2026-06-19T03:15:50.019325Z
-updated_at: 2026-06-19T03:15:50.019325Z
+updated_at: 2026-06-19T18:13:14.397020Z
 parent: herdr-pluck-t3sf
 blocked_by:
 - herdr-pluck-jyye
@@ -34,3 +34,31 @@ The v1 alphabet uses all lowercase letters in home-row-ish order: home row first
 - Unit tests cover one-character and two-character hint generation.
 - Unit tests cover fixed-width selection, max capacity truncation, deterministic ordering, duplicate mapping, and exact/invalid hint lookup behavior.
 - `cargo test` passes.
+
+
+
+## Implementation Notes
+- Replaced lexical `BTreeMap` assignment with caller-order-preserving assignment using an ordered builder list and text-to-index lookup.
+- Added `HintAssignments` wrapper with immutable assignment access, width reporting, exact hint-to-copied-text lookup, valid hint iteration, and owned conversion for downstream renderer/input integration.
+- Added `HINT_ALPHABET`, `MAX_HINT_CAPACITY`, zero-match/no-width behavior, one- and two-character deterministic hint generation, and silent cap at 676 unique copied texts.
+- Duplicate copied texts now share one hint and retain all occurrences; duplicates of already-assigned texts are retained even after the unique-text cap is reached.
+- Added `unicode-width 0.2.2` after checking the current stable crate version and exposed a `display_width` helper for future Unicode-aware renderer/input work.
+- Left `src/input.rs` untouched; future picker/input work can consume `HintAssignments::width`, `valid_hints`, and `copied_text_for_hint`.
+
+## Verification Results
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.
+
+
+
+## Review Follow-up
+- Derived `MAX_HINT_CAPACITY` from `HINT_ALPHABET.len()` to prevent drift if the alphabet changes.
+- Documented that `HintAssignments::len()` counts unique assigned copied texts, not total match occurrences.
+- Documented that `HintAssignments::width()` is fixed typed hint character width, not Unicode display column width.
+- Fixed the `AGENTS.md` typo: `documentaiton` -> `documentation`.
+
+## Review Follow-up Verification
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.

--- a/.ish/herdr-pluck-clt9--finalize-plugin-packaging-and-v1-verification.md
+++ b/.ish/herdr-pluck-clt9--finalize-plugin-packaging-and-v1-verification.md
@@ -38,8 +38,8 @@ This task should not add deferred scope such as OSC52, custom regex configuratio
 
 
 ## Reference Code
-When finalizing docs and install instructions, verify the current Herdr plugin/keybinding shape against:
+When finalizing docs and install instructions, verify the current Herdr plugin/keybinding shape against the online Herdr repository: https://github.com/ogulcancelik/herdr
 
-- `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/plugins.mdx`
-- `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/configuration.mdx`
-- `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/cli-reference.mdx`
+- [`website/src/content/docs/plugins.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/plugins.mdx)
+- [`website/src/content/docs/configuration.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/configuration.mdx)
+- [`website/src/content/docs/cli-reference.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/cli-reference.mdx)

--- a/.ish/herdr-pluck-gz33--implement-clipboard-fallback-adapter.md
+++ b/.ish/herdr-pluck-gz33--implement-clipboard-fallback-adapter.md
@@ -36,7 +36,7 @@ Target fallback coverage from the PRD: macOS `pbcopy`; Linux Wayland tools such 
 
 
 ## Reference Code
-Use tmux-fingers clipboard behavior as prior art for shelling out to available platform tools, while implementing Herdr Pluck's isolated/testable Rust adapter:
+Use tmux-fingers clipboard behavior as prior art for shelling out to available platform tools, while implementing Herdr Pluck's isolated/testable Rust adapter. Online repo: https://github.com/Morantron/tmux-fingers
 
-- `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/fingers/action_runner.cr`
-- `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/tmux.cr`
+- [`src/fingers/action_runner.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/action_runner.cr)
+- [`src/tmux.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/tmux.cr)

--- a/.ish/herdr-pluck-jyye--scaffold-rust-herdr-pluck-plugin-project.md
+++ b/.ish/herdr-pluck-jyye--scaffold-rust-herdr-pluck-plugin-project.md
@@ -35,11 +35,11 @@ None. This is the foundation for implementation work.
 
 
 ## Reference Code
-Before choosing project shape and manifest/action assumptions, inspect Herdr's plugin and CLI docs in the cached reference checkout:
+Before choosing project shape and manifest/action assumptions, inspect Herdr's plugin and CLI docs in the online Herdr repository: https://github.com/ogulcancelik/herdr
 
-- `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/plugins.mdx`
-- `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/cli-reference.mdx`
-- `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/configuration.mdx`
+- [`website/src/content/docs/plugins.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/plugins.mdx)
+- [`website/src/content/docs/cli-reference.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/cli-reference.mdx)
+- [`website/src/content/docs/configuration.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/configuration.mdx)
 
 
 

--- a/.ish/herdr-pluck-obnm--implement-built-in-pattern-engine.md
+++ b/.ish/herdr-pluck-obnm--implement-built-in-pattern-engine.md
@@ -38,8 +38,8 @@ Built-in v1 patterns are hardcoded. User-defined regex configuration is out of s
 
 
 ## Reference Code
-Use tmux-fingers as behavioral prior art, not as a requirement to clone every feature:
+Use tmux-fingers as behavioral prior art, not as a requirement to clone every feature. Online repo: https://github.com/Morantron/tmux-fingers
 
-- Capture/start flow and joined wrapped-line behavior: `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/fingers/commands/start.cr`
-- tmux capture/copy helper behavior: `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/tmux.cr`
-- Matching, named `match` capture, duplicate hint reuse, and skip-shorter-than-hint behavior: `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/fingers/hinter.cr`
+- Capture/start flow and joined wrapped-line behavior: [`src/fingers/commands/start.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/commands/start.cr)
+- tmux capture/copy helper behavior: [`src/tmux.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/tmux.cr)
+- Matching, named `match` capture, duplicate hint reuse, and skip-shorter-than-hint behavior: [`src/fingers/hinter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/hinter.cr)

--- a/.ish/herdr-pluck-t3sf--herdr-pluck-inline-hints-v1.md
+++ b/.ish/herdr-pluck-t3sf--herdr-pluck-inline-hints-v1.md
@@ -31,20 +31,20 @@ No external ish prerequisites. Child ishes and explicit `blocked_by` relationshi
 
 
 ## Reference Repositories
-Remote reference code has been cached locally with the librarian workflow. Future agents should prefer these local paths for research and grep/read operations:
+Use the online repositories as the stable source for reference code and documentation:
 
-- Herdr: `https://github.com/ogulcancelik/herdr` cached at `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr`
-- tmux-fingers: `https://github.com/Morantron/tmux-fingers` cached at `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers`
+- Herdr: https://github.com/ogulcancelik/herdr
+- tmux-fingers: https://github.com/Morantron/tmux-fingers
 
 Important PRD reference files to inspect before implementation details:
 
-- Herdr plugin authoring: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/plugins.mdx`
-- Herdr CLI reference: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/cli-reference.mdx`
-- Herdr socket/API overview: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/socket-api.mdx`
-- Herdr config/keybindings: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/configuration.mdx`
-- Herdr pane schema/layout: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/src/api/schema/panes.rs`
-- Herdr terminal read behavior: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/src/pane/terminal.rs`
-- tmux-fingers capture flow: `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/fingers/commands/start.cr` and `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/tmux.cr`
-- tmux-fingers matching/hinting: `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/fingers/hinter.cr`
-- tmux-fingers destructive rendering: `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/fingers/match_formatter.cr`
-- tmux-fingers clipboard behavior: `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/fingers/action_runner.cr` and `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/tmux.cr`
+- Herdr plugin authoring: [`website/src/content/docs/plugins.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/plugins.mdx)
+- Herdr CLI reference: [`website/src/content/docs/cli-reference.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/cli-reference.mdx)
+- Herdr socket/API overview: [`website/src/content/docs/socket-api.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/socket-api.mdx)
+- Herdr config/keybindings: [`website/src/content/docs/configuration.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/configuration.mdx)
+- Herdr pane schema/layout: [`src/api/schema/panes.rs`](https://github.com/ogulcancelik/herdr/blob/main/src/api/schema/panes.rs)
+- Herdr terminal read behavior: [`src/pane/terminal.rs`](https://github.com/ogulcancelik/herdr/blob/main/src/pane/terminal.rs)
+- tmux-fingers capture flow: [`src/fingers/commands/start.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/commands/start.cr) and [`src/tmux.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/tmux.cr)
+- tmux-fingers matching/hinting: [`src/fingers/hinter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/hinter.cr)
+- tmux-fingers destructive rendering: [`src/fingers/match_formatter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/match_formatter.cr)
+- tmux-fingers clipboard behavior: [`src/fingers/action_runner.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/action_runner.cr) and [`src/tmux.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/tmux.cr)

--- a/.ish/herdr-pluck-vhdh--implement-herdr-adapter-and-overlay-action.md
+++ b/.ish/herdr-pluck-vhdh--implement-herdr-adapter-and-overlay-action.md
@@ -39,11 +39,11 @@ Use Herdr's documented plugin/CLI/socket APIs, not private internals. Relevant P
 
 
 ## Reference Code
-Use the cached Herdr checkout as the source for exact plugin/CLI/API behavior:
+Use the online Herdr repository as the source for exact plugin/CLI/API behavior: https://github.com/ogulcancelik/herdr
 
-- Plugin model/manifest/action/overlay docs: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/plugins.mdx`
-- CLI commands including `pane read` and `plugin pane open`: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/cli-reference.mdx`
-- Socket/API overview including pane APIs: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/socket-api.mdx`
-- Keybinding `plugin_action` docs: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/website/src/content/docs/configuration.mdx`
-- Pane layout schema: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/src/api/schema/panes.rs`
-- Terminal read implementation and `recent_unwrapped` behavior: `/Users/rmarganti/.cache/checkouts/github.com/ogulcancelik/herdr/src/pane/terminal.rs`
+- Plugin model/manifest/action/overlay docs: [`website/src/content/docs/plugins.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/plugins.mdx)
+- CLI commands including `pane read` and `plugin pane open`: [`website/src/content/docs/cli-reference.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/cli-reference.mdx)
+- Socket/API overview including pane APIs: [`website/src/content/docs/socket-api.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/socket-api.mdx)
+- Keybinding `plugin_action` docs: [`website/src/content/docs/configuration.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/configuration.mdx)
+- Pane layout schema: [`src/api/schema/panes.rs`](https://github.com/ogulcancelik/herdr/blob/main/src/api/schema/panes.rs)
+- Terminal read implementation and `recent_unwrapped` behavior: [`src/pane/terminal.rs`](https://github.com/ogulcancelik/herdr/blob/main/src/pane/terminal.rs)

--- a/.ish/herdr-pluck-z4cv--implement-inline-overlay-renderer.md
+++ b/.ish/herdr-pluck-z4cv--implement-inline-overlay-renderer.md
@@ -38,7 +38,7 @@ Rendering must preserve geometry: hints destructively replace the beginning of t
 
 
 ## Reference Code
-Use tmux-fingers destructive inline rendering as prior art:
+Use tmux-fingers destructive inline rendering as prior art. Online repo: https://github.com/Morantron/tmux-fingers
 
-- `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/fingers/match_formatter.cr`
-- Related hint/match data behavior: `/Users/rmarganti/.cache/checkouts/github.com/Morantron/tmux-fingers/src/fingers/hinter.cr`
+- [`src/fingers/match_formatter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/match_formatter.cr)
+- Related hint/match data behavior: [`src/fingers/hinter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/hinter.cr)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,10 @@
+## Code documentation
+
+- Add SUCCINCT docblocks to structs and methods.
+- Give an added focus to Domain definitions.
+- Do NOT document things that are painfully obvious. For example, a `Rect { w: int64, h: int64 }` has no need for documentation.
+- If an implication is particularly complicated, document implementation sections.
+
 ## Verifying (MUST BE RUN BEFORE CONSIDERING A TASK COMPLETE)
 
 - `cargo fmt --all -- --check`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "unicode-width",
  "which",
 ]
 
@@ -495,6 +496,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
+unicode-width = "0.2.2"
 which = "6.0"
 
 [dev-dependencies]

--- a/src/hints.rs
+++ b/src/hints.rs
@@ -1,55 +1,287 @@
 use crate::model::{HintAssignment, MatchSpan};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
+use unicode_width::UnicodeWidthStr;
 
+pub const HINT_ALPHABET: &str = "asdfghjklqwertyuiopzxcvbnm";
 pub const MAX_HINT_WIDTH: usize = 2;
+pub const MAX_HINT_CAPACITY: usize = HINT_ALPHABET.len() * HINT_ALPHABET.len();
 
-pub fn hint_alphabet() -> Vec<char> {
-    "asdfghjklqwertyuiopzxcvbnm".chars().collect()
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HintAssignments {
+    assignments: Vec<HintAssignment>,
 }
 
-/// Determines the appropriate hint width based on the number of unique match texts.
-pub fn hint_width(unique_match_count: usize) -> usize {
-    let alphabet_len = hint_alphabet().len();
-    if unique_match_count <= alphabet_len {
-        1
-    } else {
-        MAX_HINT_WIDTH
+impl HintAssignments {
+    pub fn new(assignments: Vec<HintAssignment>) -> Self {
+        Self { assignments }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.assignments.is_empty()
+    }
+
+    /// Returns the number of unique copied texts with assigned hints, not total occurrences.
+    pub fn len(&self) -> usize {
+        self.assignments.len()
+    }
+
+    /// Returns the fixed hint width in typed characters, not Unicode display columns.
+    pub fn width(&self) -> Option<usize> {
+        self.assignments
+            .first()
+            .map(|assignment| assignment.hint.chars().count())
+    }
+
+    pub fn assignments(&self) -> &[HintAssignment] {
+        &self.assignments
+    }
+
+    pub fn into_assignments(self) -> Vec<HintAssignment> {
+        self.assignments
+    }
+
+    pub fn copied_text_for_hint(&self, hint: &str) -> Option<&str> {
+        self.assignments
+            .iter()
+            .find(|assignment| assignment.hint == hint)
+            .map(|assignment| assignment.text.as_str())
+    }
+
+    pub fn valid_hints(&self) -> impl Iterator<Item = &str> {
+        self.assignments
+            .iter()
+            .map(|assignment| assignment.hint.as_str())
     }
 }
 
-/// Generates hints based on the specified width. For width 1, it generates single-character hints
-/// from the alphabet. For width 2, it generates all possible two-character combinations from the
-/// alphabet. Widths greater than 2 are not supported and will return an empty vector.
+#[derive(Debug)]
+struct AssignmentBuilder {
+    text: String,
+    occurrences: Vec<MatchSpan>,
+}
+
+pub fn hint_alphabet() -> &'static str {
+    HINT_ALPHABET
+}
+
+/// Determines the appropriate fixed hint width for a number of unique copied texts.
+pub fn hint_width(unique_match_count: usize) -> Option<usize> {
+    match unique_match_count {
+        0 => None,
+        1..=26 => Some(1),
+        _ => Some(MAX_HINT_WIDTH),
+    }
+}
+
+/// Generates hints based on the specified width.
 pub fn generate_hints(width: usize) -> Vec<String> {
-    let alphabet = hint_alphabet();
     match width {
-        0 => Vec::new(),
-        1 => alphabet.iter().map(char::to_string).collect(),
-        2 => alphabet
-            .iter()
-            .flat_map(|a| alphabet.iter().map(move |b| format!("{a}{b}")))
+        1 => HINT_ALPHABET.chars().map(|ch| ch.to_string()).collect(),
+        2 => HINT_ALPHABET
+            .chars()
+            .flat_map(|first| {
+                HINT_ALPHABET
+                    .chars()
+                    .map(move |second| format!("{first}{second}"))
+            })
             .collect(),
         _ => Vec::new(),
     }
 }
 
-/// Assigns hints to the given matches. Hints are generated based on the number of unique match texts.
-pub fn assign_hints(matches: Vec<MatchSpan>) -> Vec<HintAssignment> {
-    let mut by_text: BTreeMap<String, Vec<MatchSpan>> = BTreeMap::new();
-    for span in matches {
-        by_text.entry(span.text.clone()).or_default().push(span);
+/// Returns the Unicode display width of text in terminal columns.
+pub fn display_width(text: &str) -> usize {
+    UnicodeWidthStr::width(text)
+}
+
+/// Assigns fixed-width hints to copied texts in the caller-provided first-visible order.
+///
+/// The caller is responsible for sorting matches top-to-bottom and left-to-right. Duplicate copied
+/// text shares the first assigned hint while retaining every visible occurrence. New unique copied
+/// texts beyond the v1 capacity are silently omitted, but later duplicates of already-assigned
+/// copied texts are still retained.
+pub fn assign_hints(matches: Vec<MatchSpan>) -> HintAssignments {
+    if matches.is_empty() {
+        return HintAssignments::new(Vec::new());
     }
 
-    let width = hint_width(by_text.len());
-    let hints = generate_hints(width);
+    let mut by_text: HashMap<String, usize> = HashMap::new();
+    let mut ordered: Vec<AssignmentBuilder> = Vec::new();
 
-    by_text
+    for span in matches {
+        if let Some(index) = by_text.get(&span.text).copied() {
+            ordered[index].occurrences.push(span);
+            continue;
+        }
+
+        if ordered.len() < MAX_HINT_CAPACITY {
+            let index = ordered.len();
+            by_text.insert(span.text.clone(), index);
+            ordered.push(AssignmentBuilder {
+                text: span.text.clone(),
+                occurrences: vec![span],
+            });
+        }
+    }
+
+    let Some(width) = hint_width(ordered.len()) else {
+        return HintAssignments::new(Vec::new());
+    };
+
+    let hints = generate_hints(width);
+    let assignments = ordered
         .into_iter()
         .zip(hints)
-        .map(|((text, occurrences), hint)| HintAssignment {
+        .map(|(builder, hint)| HintAssignment {
             hint,
-            text,
-            occurrences,
+            text: builder.text,
+            occurrences: builder.occurrences,
         })
-        .collect()
+        .collect();
+
+    HintAssignments::new(assignments)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test helper to create a MatchSpan with the specified text and position,
+    /// using default pattern and priority.
+    fn span(text: impl Into<String>, line: usize, start: usize) -> MatchSpan {
+        let text = text.into();
+        MatchSpan {
+            line,
+            start,
+            end: start + text.len(),
+            text,
+            pattern: "test".to_string(),
+            priority: 10,
+        }
+    }
+
+    #[test]
+    fn unsupported_hint_width_generates_no_hints() {
+        assert!(generate_hints(0).is_empty());
+        assert!(generate_hints(3).is_empty());
+    }
+
+    #[test]
+    fn zero_matches_produce_empty_assignments() {
+        let assignments = assign_hints(Vec::new());
+
+        assert!(assignments.is_empty());
+        assert_eq!(assignments.len(), 0);
+        assert_eq!(assignments.width(), None);
+    }
+
+    #[test]
+    fn assignment_preserves_caller_provided_order() {
+        let assignments = assign_hints(vec![
+            span("zeta", 3, 0),
+            span("alpha", 0, 0),
+            span("middle", 2, 0),
+        ]);
+        let texts: Vec<&str> = assignments
+            .assignments()
+            .iter()
+            .map(|assignment| assignment.text.as_str())
+            .collect();
+
+        assert_eq!(texts, vec!["zeta", "alpha", "middle"]);
+        assert_eq!(assignments.assignments()[0].hint, "a");
+        assert_eq!(assignments.assignments()[1].hint, "s");
+        assert_eq!(assignments.assignments()[2].hint, "d");
+    }
+
+    #[test]
+    fn duplicate_text_shares_hint_and_retains_occurrences() {
+        let assignments = assign_hints(vec![
+            span("foo", 0, 0),
+            span("bar", 0, 4),
+            span("foo", 1, 2),
+        ]);
+
+        assert_eq!(assignments.len(), 2);
+        assert_eq!(assignments.assignments()[0].text, "foo");
+        assert_eq!(assignments.assignments()[0].hint, "a");
+        assert_eq!(assignments.assignments()[0].occurrences.len(), 2);
+        assert_eq!(assignments.assignments()[1].text, "bar");
+        assert_eq!(assignments.assignments()[1].hint, "s");
+    }
+
+    #[test]
+    fn caps_unique_texts_at_two_character_capacity() {
+        let matches: Vec<MatchSpan> = (0..700)
+            .map(|index| span(format!("token-{index}"), index, 0))
+            .collect();
+
+        let assignments = assign_hints(matches);
+
+        assert_eq!(assignments.len(), MAX_HINT_CAPACITY);
+        assert_eq!(assignments.width(), Some(2));
+        assert_eq!(assignments.assignments().first().unwrap().hint, "aa");
+        assert_eq!(assignments.assignments().last().unwrap().hint, "mm");
+        assert!(assignments
+            .assignments()
+            .iter()
+            .all(|assignment| assignment.text != "token-676"));
+    }
+
+    #[test]
+    fn duplicate_after_cap_is_retained_for_assigned_text() {
+        let mut matches: Vec<MatchSpan> = (0..MAX_HINT_CAPACITY)
+            .map(|index| span(format!("token-{index}"), index, 0))
+            .collect();
+        matches.push(span("beyond-cap", MAX_HINT_CAPACITY, 0));
+        matches.push(span("token-0", MAX_HINT_CAPACITY + 1, 0));
+
+        let assignments = assign_hints(matches);
+
+        assert_eq!(assignments.len(), MAX_HINT_CAPACITY);
+        assert_eq!(assignments.assignments()[0].text, "token-0");
+        assert_eq!(assignments.assignments()[0].occurrences.len(), 2);
+        assert!(assignments
+            .assignments()
+            .iter()
+            .all(|assignment| assignment.text != "beyond-cap"));
+    }
+
+    #[test]
+    fn lookup_returns_copied_text_for_exact_hint() {
+        let assignments = assign_hints(vec![span("first text", 0, 0), span("second text", 0, 11)]);
+
+        assert_eq!(assignments.copied_text_for_hint("a"), Some("first text"));
+        assert_eq!(assignments.copied_text_for_hint("s"), Some("second text"));
+        assert_eq!(assignments.copied_text_for_hint("x"), None);
+    }
+
+    #[test]
+    fn lookup_works_for_two_character_hints() {
+        let matches: Vec<MatchSpan> = (0..27)
+            .map(|index| span(format!("token-{index}"), index, 0))
+            .collect();
+
+        let assignments = assign_hints(matches);
+
+        assert_eq!(assignments.width(), Some(2));
+        assert_eq!(assignments.copied_text_for_hint("aa"), Some("token-0"));
+        assert_eq!(assignments.copied_text_for_hint("sa"), Some("token-26"));
+        assert_eq!(assignments.copied_text_for_hint("a"), None);
+    }
+
+    #[test]
+    fn valid_hints_iterates_assigned_hints() {
+        let assignments = assign_hints(vec![span("foo", 0, 0), span("bar", 0, 4)]);
+        let hints: Vec<&str> = assignments.valid_hints().collect();
+
+        assert_eq!(hints, vec!["a", "s"]);
+    }
+
+    #[test]
+    fn display_width_uses_unicode_terminal_columns() {
+        assert_eq!(display_width("abc"), 3);
+        assert_eq!(display_width("é"), 1);
+        assert_eq!(display_width("🔥"), 2);
+    }
 }


### PR DESCRIPTION
## Summary
- add caller-order-preserving fixed-width hint assignment
- cap v1 hinting at 676 unique copied texts and retain duplicate occurrences
- expose hint assignment lookup helpers for future picker/input integration
- add Unicode display-width helper and tests
- record Ish completion and review follow-up notes

## Verification
- cargo fmt --all -- --check
- cargo test --all-features
- cargo clippy --all-targets --all
- ish check