### PR TITLE
feat: implement built-in pattern engine

### DIFF
--- a/.ish/herdr-pluck-g57o--support-expanded-tmux-fingers-compatible-pattern-s.md
+++ b/.ish/herdr-pluck-g57o--support-expanded-tmux-fingers-compatible-pattern-s.md
@@ -1,0 +1,33 @@
+---
+# herdr-pluck-g57o
+title: Support expanded tmux-fingers-compatible pattern set
+status: todo
+type: task
+priority: low
+tags:
+- pluck
+- matching
+- deferred
+created_at: 2026-06-19T18:34:14.319819Z
+updated_at: 2026-06-19T18:34:14.319819Z
+parent: herdr-pluck-t3sf
+blocked_by:
+- herdr-pluck-obnm
+---
+
+## Context
+Herdr Pluck v1 intentionally ships with the PRD's six built-in pattern classes: URLs, file paths, UUIDs, Git SHAs, IPv4 addresses, and long numeric identifiers. After v1, consider expanding built-ins toward tmux-fingers parity and other commonly useful terminal tokens.
+
+Use tmux-fingers as prior art for additional built-ins, but do not blindly add patterns without checking overlap, false-positive behavior, and hint usability in Herdr Pluck's copy-only workflow.
+
+## Work
+- Review tmux-fingers built-ins beyond the six v1 classes: `hex`, `kubernetes`, `kubernetes-pod`, `git-status`, `git-status-branch`, and `diff`.
+- Identify any additional Herdr Pluck-specific patterns worth supporting.
+- Decide whether expanded built-ins are always enabled or configurable.
+- Add tests for each accepted pattern, named `match` captures, overlap resolution with existing higher-priority patterns, and false-positive boundaries.
+- Document supported expanded patterns and any intentionally omitted tmux-fingers patterns.
+
+## Verification
+- Pattern tests cover every newly accepted class.
+- Existing v1 pattern behavior remains unchanged unless deliberately documented.
+- Project verification passes.

--- a/.ish/herdr-pluck-obnm--implement-built-in-pattern-engine.md
+++ b/.ish/herdr-pluck-obnm--implement-built-in-pattern-engine.md
@@ -1,14 +1,14 @@
 ---
 # herdr-pluck-obnm
 title: Implement built-in pattern engine
-status: todo
+status: completed
 type: task
 priority: high
 tags:
 - pluck
 - matching
 created_at: 2026-06-19T03:15:42.545423Z
-updated_at: 2026-06-19T03:21:41.649243Z
+updated_at: 2026-06-19T18:50:57.258389Z
 parent: herdr-pluck-t3sf
 blocked_by:
 - herdr-pluck-jyye
@@ -43,3 +43,19 @@ Use tmux-fingers as behavioral prior art, not as a requirement to clone every fe
 - Capture/start flow and joined wrapped-line behavior: [`src/fingers/commands/start.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/commands/start.cr)
 - tmux capture/copy helper behavior: [`src/tmux.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/tmux.cr)
 - Matching, named `match` capture, duplicate hint reuse, and skip-shorter-than-hint behavior: [`src/fingers/hinter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/hinter.cr)
+
+
+## Implementation Notes
+- Replaced the scaffold matcher with a shallow public API, `patterns::find_matches(&[String]) -> Vec<MatchSpan>`, backed by cached hardcoded built-in regexes.
+- Kept `PatternDefinition` and custom-pattern plumbing private so callers receive resolved, first-visible-order matches without composing matcher internals.
+- Implemented the six v1 pattern classes only: tmux-fingers-compatible URL schemes/delimiters, tmux-fingers path behavior, uppercase/lowercase UUIDs, uppercase/lowercase 7-40 byte Git SHAs, loose tmux-fingers IPv4 addresses, and tmux-fingers long numeric identifiers.
+- Implemented named `match` capture handling so the copied/highlighted capture range becomes the `MatchSpan` range and overlap range.
+- Implemented overlap resolution within each logical line using priority ascending, byte length descending, position, and internal pattern definition order as the deterministic fallback.
+- Preserved duplicate copied-text occurrences for `hints::assign_hints` to deduplicate later, and sorted final output top-to-bottom/left-to-right for hint assignment.
+- Documented `MatchSpan` byte-offset and lower-number-higher-priority semantics in `src/model.rs`.
+
+## Verification Results
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.
+- `ish check` passed.

--- a/src/model.rs
+++ b/src/model.rs
@@ -93,15 +93,33 @@ pub struct PaneText {
     pub dimensions: PaneDimensions,
 }
 
-/// A single occurrence of a matched pattern in the pane text.
+/// Copied/highlighted occurrence found on one unwrapped logical pane line.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MatchSpan {
+    /// Zero-based logical line index.
     pub line: usize,
+    /// UTF-8 byte offset where the copied/highlighted substring starts.
     pub start: usize,
+    /// UTF-8 byte offset immediately after the copied/highlighted substring.
     pub end: usize,
+    /// Copied text; for regexes with named capture `match`, this is that capture.
     pub text: String,
+    /// Built-in pattern name that produced this occurrence.
     pub pattern: String,
+    /// Match precedence where lower numbers are higher priority.
     pub priority: u16,
+}
+
+impl MatchSpan {
+    /// Returns the matched byte length used by matcher tie-breaking.
+    pub fn len_bytes(&self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Returns whether copied/highlighted byte ranges overlap on the same logical line.
+    pub fn overlaps(&self, other: &Self) -> bool {
+        self.line == other.line && self.start < other.end && other.start < self.end
+    }
 }
 
 /// A unique matched text pattern and all its occurrences in the pane.

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -1,78 +1,404 @@
 use crate::model::MatchSpan;
 use regex::Regex;
+use std::sync::OnceLock;
 
-#[derive(Debug, Clone)]
-pub struct PatternDefinition {
-    pub name: &'static str,
-    pub priority: u16,
-    pub regex: Regex,
+static BUILT_IN_PATTERNS: OnceLock<Vec<PatternDefinition>> = OnceLock::new();
+
+#[derive(Debug)]
+struct PatternDefinition {
+    name: &'static str,
+    /// Match precedence where lower numbers beat higher numbers.
+    /// ie. `1` is the number one priority, while `5` is a lower priority
+    priority: u16,
+    regex: Regex,
 }
 
 impl PatternDefinition {
-    pub fn new(name: &'static str, priority: u16, pattern: &str) -> Result<Self, regex::Error> {
-        Ok(Self {
+    fn compile(name: &'static str, priority: u16, pattern: &str) -> Self {
+        Self {
             name,
             priority,
-            regex: Regex::new(pattern)?,
-        })
+            regex: Regex::new(pattern).expect("built-in Herdr Pluck pattern must compile"),
+        }
     }
 }
 
-pub fn built_in_patterns() -> Result<Vec<PatternDefinition>, regex::Error> {
-    Ok(vec![
-        PatternDefinition::new("url", 10, r#"https?://[^\s<>'\"]+"#)?,
-        PatternDefinition::new(
-            "path",
-            20,
-            r#"(?:\./|\.\./|/|~/?)[A-Za-z0-9._~+@%:=-]+(?:/[A-Za-z0-9._~+@%:=-]+)+"#,
-        )?,
-        PatternDefinition::new(
-            "uuid",
-            30,
-            r#"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"#,
-        )?,
-        //
-        PatternDefinition::new("git-sha", 40, r#"\b[0-9a-fA-F]{7,40}\b"#)?,
-        PatternDefinition::new("ipv4", 50, r#"\b(?:\d{1,3}\.){3}\d{1,3}\b"#)?,
-        PatternDefinition::new("number", 60, r#"\b\d{4,}\b"#)?,
-    ])
+/// Candidate match occurrence with its pattern definition order for tie-breaking.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MatchCandidate {
+    span: MatchSpan,
+    pattern_order: usize,
 }
 
-/// Finds matches in the given lines based on the provided patterns. Each match is represented as a `MatchSpan`
-/// containing the line index, start and end positions, matched text, pattern name, and pattern priority.
-pub fn find_raw_matches(lines: &[String], patterns: &[PatternDefinition]) -> Vec<MatchSpan> {
-    let mut spans = Vec::new();
+/// Finds accepted built-in pattern matches in first-visible order.
+///
+/// Matching runs on unwrapped logical lines. Returned spans are all accepted visible occurrences;
+/// duplicate copied texts are intentionally preserved for the hint engine to deduplicate later.
+pub fn find_matches(lines: &[String]) -> Vec<MatchSpan> {
+    find_matches_with_patterns(lines, built_in_patterns())
+}
+
+fn built_in_patterns() -> &'static [PatternDefinition] {
+    BUILT_IN_PATTERNS.get_or_init(|| {
+        vec![
+            PatternDefinition::compile(
+                "url",
+                10,
+                r#"((https?://|git@|git://|ssh://|ftp://|file:///)[^\s()"']+)"#,
+            ),
+            PatternDefinition::compile("path", 20, r#"(([.\w\-~\$@]+)?(/[.\w\-@]+)+/?)"#),
+            PatternDefinition::compile(
+                "uuid",
+                30,
+                r#"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"#,
+            ),
+            PatternDefinition::compile("git-sha", 40, r#"\b[0-9a-fA-F]{7,40}\b"#),
+            PatternDefinition::compile("ipv4", 50, r#"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"#),
+            PatternDefinition::compile("number", 60, r#"[0-9]{4,}"#),
+        ]
+    })
+}
+
+fn find_matches_with_patterns(lines: &[String], patterns: &[PatternDefinition]) -> Vec<MatchSpan> {
+    let candidates = collect_candidates(lines, patterns);
+    let mut accepted = resolve_overlaps(candidates);
+    accepted.sort_by(|left, right| {
+        left.line
+            .cmp(&right.line)
+            .then_with(|| left.start.cmp(&right.start))
+            .then_with(|| left.end.cmp(&right.end))
+    });
+    accepted
+}
+
+/// Collects all candidate matches for all patterns with their pattern definition order for tie-breaking.
+fn collect_candidates(lines: &[String], patterns: &[PatternDefinition]) -> Vec<MatchCandidate> {
+    let mut candidates = Vec::new();
+
     for (line_idx, line) in lines.iter().enumerate() {
-        for pattern in patterns {
+        for (pattern_order, pattern) in patterns.iter().enumerate() {
             for captures in pattern.regex.captures_iter(line) {
-                let m = captures.name("match").or_else(|| captures.get(0));
-                if let Some(m) = m {
-                    spans.push(MatchSpan {
+                let Some(regex_match) = captures.name("match").or_else(|| captures.get(0)) else {
+                    continue;
+                };
+
+                candidates.push(MatchCandidate {
+                    span: MatchSpan {
                         line: line_idx,
-                        start: m.start(),
-                        end: m.end(),
-                        text: m.as_str().to_string(),
+                        start: regex_match.start(),
+                        end: regex_match.end(),
+                        text: regex_match.as_str().to_string(),
                         pattern: pattern.name.to_string(),
                         priority: pattern.priority,
-                    });
-                }
+                    },
+                    pattern_order,
+                });
             }
         }
     }
-    spans
+
+    candidates
+}
+
+/// Resolves overlapping candidates by acceptance priority where lower numbers are higher priority.
+fn resolve_overlaps(mut candidates: Vec<MatchCandidate>) -> Vec<MatchSpan> {
+    candidates.sort_by(|left, right| {
+        left.span
+            .priority
+            .cmp(&right.span.priority)
+            .then_with(|| right.span.len_bytes().cmp(&left.span.len_bytes()))
+            .then_with(|| left.span.line.cmp(&right.span.line))
+            .then_with(|| left.span.start.cmp(&right.span.start))
+            .then_with(|| left.span.end.cmp(&right.span.end))
+            .then_with(|| left.pattern_order.cmp(&right.pattern_order))
+    });
+
+    let mut accepted: Vec<MatchSpan> = Vec::new();
+    for candidate in candidates {
+        if accepted
+            .iter()
+            .all(|accepted_span| !candidate.span.overlaps(accepted_span))
+        {
+            accepted.push(candidate.span);
+        }
+    }
+
+    accepted
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn built_in_patterns_compile_and_find_smoke_matches() {
-        let patterns = built_in_patterns().unwrap();
-        let lines = vec!["see https://example.com and /tmp/foo/bar".to_string()];
-        let matches = find_raw_matches(&lines, &patterns);
+    fn lines<const N: usize>(values: [&str; N]) -> Vec<String> {
+        values.into_iter().map(String::from).collect()
+    }
 
-        assert!(matches.iter().any(|m| m.pattern == "url"));
-        assert!(matches.iter().any(|m| m.pattern == "path"));
+    fn test_pattern(name: &'static str, priority: u16, pattern: &str) -> PatternDefinition {
+        PatternDefinition::compile(name, priority, pattern)
+    }
+
+    #[test]
+    fn finds_url_schemes() {
+        let matches = find_matches(&lines([
+            "https://example.com http://example.com git@github.com:org/repo.git",
+            "git://host/repo ssh://host/path ftp://host/path file:///tmp/file",
+        ]));
+        let urls: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "url")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(
+            urls,
+            vec![
+                "https://example.com",
+                "http://example.com",
+                "git@github.com:org/repo.git",
+                "git://host/repo",
+                "ssh://host/path",
+                "ftp://host/path",
+                "file:///tmp/file",
+            ]
+        );
+    }
+
+    #[test]
+    fn url_stops_at_delimiters() {
+        let matches = find_matches(&lines([
+            "(https://a.test/path) 'https://b.test' \"https://c.test\"",
+        ]));
+        let urls: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "url")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(
+            urls,
+            vec!["https://a.test/path", "https://b.test", "https://c.test"]
+        );
+    }
+
+    #[test]
+    fn url_preserves_non_delimiter_trailing_punctuation() {
+        let matches = find_matches(&lines(["see https://example.com/path., next"]));
+        let url = matches.iter().find(|span| span.pattern == "url").unwrap();
+
+        assert_eq!(url.text, "https://example.com/path.,");
+    }
+
+    #[test]
+    fn finds_style_paths() {
+        let matches = find_matches(&lines(["/tmp/foo/bar src/main.rs foo/bar dir/sub/"]));
+        let paths: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "path")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(
+            paths,
+            vec!["/tmp/foo/bar", "src/main.rs", "foo/bar", "dir/sub/"]
+        );
+    }
+
+    #[test]
+    fn finds_uppercase_and_lowercase_uuids() {
+        let matches = find_matches(&lines([
+            "ids 123e4567-e89b-12d3-a456-426614174000 123E4567-E89B-12D3-A456-426614174000",
+        ]));
+        let uuids: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "uuid")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(
+            uuids,
+            vec![
+                "123e4567-e89b-12d3-a456-426614174000",
+                "123E4567-E89B-12D3-A456-426614174000",
+            ]
+        );
+    }
+
+    #[test]
+    fn finds_git_sha_lengths_with_uppercase_support() {
+        let matches = find_matches(&lines([
+            "sha abcDEF1 abcdef1234567890abcdef1234567890abcdef12 abcdef1234567890abcdef1234567890abcdef123",
+        ]));
+        let shas: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "git-sha")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(
+            shas,
+            vec!["abcDEF1", "abcdef1234567890abcdef1234567890abcdef12"]
+        );
+    }
+
+    #[test]
+    fn finds_loose_ipv4() {
+        let matches = find_matches(&lines(["hosts 192.168.1.10 999.999.999.999"]));
+        let ips: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "ipv4")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(ips, vec!["192.168.1.10", "999.999.999.999"]);
+    }
+
+    #[test]
+    fn finds_long_numbers_inside_text() {
+        let matches = find_matches(&lines(["zzz1234zzz issue-5678 foo_9012"]));
+        let numbers: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "number")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(numbers, vec!["1234", "5678", "9012"]);
+    }
+
+    #[test]
+    fn named_match_capture_defines_text_and_range() {
+        let patterns = vec![test_pattern("status", 10, r#"status=\[(?<match>[^\]]+)\]"#)];
+        let matches = find_matches_with_patterns(&lines(["status=[copy-me]"]), &patterns);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].text, "copy-me");
+        assert_eq!(matches[0].start, 8);
+        assert_eq!(matches[0].end, 15);
+    }
+
+    #[test]
+    fn full_match_is_used_without_named_capture() {
+        let patterns = vec![test_pattern("word", 10, r#"copy-me"#)];
+        let matches = find_matches_with_patterns(&lines(["xx copy-me yy"]), &patterns);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].text, "copy-me");
+        assert_eq!(matches[0].start, 3);
+        assert_eq!(matches[0].end, 10);
+    }
+
+    #[test]
+    fn overlap_resolution_uses_named_capture_range() {
+        let patterns = vec![
+            test_pattern("wrapped", 10, r#"prefix-(?<match>abc)-suffix"#),
+            test_pattern("prefix", 20, r#"prefix"#),
+        ];
+        let matches = find_matches_with_patterns(&lines(["prefix-abc-suffix"]), &patterns);
+        let texts: Vec<&str> = matches.iter().map(|span| span.text.as_str()).collect();
+
+        assert_eq!(texts, vec!["prefix", "abc"]);
+    }
+
+    #[test]
+    fn url_wins_over_path_inside_url() {
+        let matches = find_matches(&lines(["open https://example.com/src/main.rs"]));
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].pattern, "url");
+        assert_eq!(matches[0].text, "https://example.com/src/main.rs");
+    }
+
+    #[test]
+    fn uuid_wins_over_sha_and_number_submatches() {
+        let matches = find_matches(&lines(["id 123e4567-e89b-12d3-a456-426614174000"]));
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].pattern, "uuid");
+    }
+
+    #[test]
+    fn git_sha_wins_over_number_submatch() {
+        let matches = find_matches(&lines(["sha abc1234"]));
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].pattern, "git-sha");
+        assert_eq!(matches[0].text, "abc1234");
+    }
+
+    #[test]
+    fn higher_priority_beats_longer_lower_priority_overlap() {
+        let patterns = vec![
+            test_pattern("short-high", 10, r#"abc"#),
+            test_pattern("long-low", 20, r#"abcdef"#),
+        ];
+        let matches = find_matches_with_patterns(&lines(["abcdef"]), &patterns);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].pattern, "short-high");
+    }
+
+    #[test]
+    fn longer_match_wins_within_same_priority() {
+        let patterns = vec![
+            test_pattern("short", 10, r#"abc"#),
+            test_pattern("long", 10, r#"abcdef"#),
+        ];
+        let matches = find_matches_with_patterns(&lines(["abcdef"]), &patterns);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].pattern, "long");
+    }
+
+    #[test]
+    fn earlier_position_wins_within_same_priority_and_length() {
+        let patterns = vec![test_pattern("word", 10, r#"abc"#)];
+        let matches = find_matches_with_patterns(&lines(["abc abc"]), &patterns);
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].start, 0);
+        assert_eq!(matches[1].start, 4);
+    }
+
+    #[test]
+    fn pattern_definition_order_breaks_exact_ties() {
+        let patterns = vec![
+            test_pattern("first", 10, r#"abc"#),
+            test_pattern("second", 10, r#"abc"#),
+        ];
+        let matches = find_matches_with_patterns(&lines(["abc"]), &patterns);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].pattern, "first");
+    }
+
+    #[test]
+    fn output_order_is_visible_order_not_acceptance_priority() {
+        let matches = find_matches(&lines(["1234", "https://example.com"]));
+        let texts: Vec<&str> = matches.iter().map(|span| span.text.as_str()).collect();
+
+        assert_eq!(texts, vec!["1234", "https://example.com"]);
+    }
+
+    #[test]
+    fn duplicate_copied_text_occurrences_are_preserved() {
+        let matches = find_matches(&lines(["/tmp/foo /tmp/foo"]));
+        let paths: Vec<&MatchSpan> = matches
+            .iter()
+            .filter(|span| span.pattern == "path")
+            .collect();
+
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0].text, paths[1].text);
+        assert_ne!(paths[0].start, paths[1].start);
+    }
+
+    #[test]
+    fn overlap_is_line_local() {
+        let patterns = vec![test_pattern("same", 10, r#"abc"#)];
+        let matches = find_matches_with_patterns(&lines(["abc", "abc"]), &patterns);
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].line, 0);
+        assert_eq!(matches[1].line, 1);
     }
 }


### PR DESCRIPTION
## Summary
- add cached built-in pattern matching for the six v1 token classes
- resolve overlaps by priority, byte length, position, and pattern definition order
- support named `match` captures while preserving duplicate visible occurrences for hint assignment
- document `MatchSpan` byte-range semantics and add deferred Ish for expanded tmux-fingers-compatible patterns

## Verification
- cargo fmt --all -- --check
- cargo test --all-features
- cargo clippy --all-targets --all
- ish check