### PR TITLE
feat: implement inline overlay renderer

### DIFF
--- a/.ish/herdr-pluck-1iof--add-renderer-terminal-smoke-output-path.md
+++ b/.ish/herdr-pluck-1iof--add-renderer-terminal-smoke-output-path.md
@@ -1,0 +1,40 @@
+---
+# herdr-pluck-1iof
+title: Add renderer terminal smoke output path
+status: todo
+type: task
+priority: high
+tags:
+- pluck
+- renderer
+- smoke
+created_at: 2026-06-19T19:16:36.267406Z
+updated_at: 2026-06-19T19:16:36.267406Z
+parent: herdr-pluck-t3sf
+blocking:
+- herdr-pluck-guwf
+blocked_by:
+- herdr-pluck-z4cv
+---
+
+## Context
+After the abstract renderer is implemented, add a small terminal-visible smoke path before the full picker input loop. This should let local Herdr overlay testing show real matched inline hints using the renderer without yet implementing hint typing/copy behavior.
+
+This is intentionally separate from the input-loop/copy-flow task so rendering can be manually validated sooner.
+
+## Dependencies
+- Blocked by `herdr-pluck-z4cv` for abstract renderer output and style semantics.
+
+## Work
+- Add a CLI or picker-placeholder path that reads target pane text and geometry when available, runs matching + hint assignment + rendering, and displays the rendered hint view in the overlay.
+- Convert abstract render styles to terminal output with simple v1 styling: dim/black non-matches, white matches, cyan hints.
+- Keep behavior non-interactive or minimally interactive: show output and wait for a key to close; do not implement hint entry or clipboard copy here.
+- Preserve the existing frozen source-geometry behavior and compose rendered source output into the overlay viewport where applicable.
+- Document exact smoke-test steps for invoking the linked Herdr plugin and visually confirming inline hints.
+
+## Verification
+- Unit tests cover style-to-terminal/emission helpers where practical without requiring a real terminal.
+- `cargo fmt --all -- --check` passes.
+- `cargo test --all-features` passes.
+- `cargo clippy --all-targets --all` passes.
+- Manual Herdr smoke test displays rendered inline hints and closes on keypress.

--- a/.ish/herdr-pluck-guwf--wire-picker-input-loop-and-copy-flow.md
+++ b/.ish/herdr-pluck-guwf--wire-picker-input-loop-and-copy-flow.md
@@ -9,7 +9,7 @@ tags:
 - picker
 - input
 created_at: 2026-06-19T03:16:25.652609Z
-updated_at: 2026-06-19T03:16:25.652609Z
+updated_at: 2026-06-19T19:16:54.039084Z
 parent: herdr-pluck-t3sf
 blocked_by:
 - herdr-pluck-obnm
@@ -17,6 +17,7 @@ blocked_by:
 - herdr-pluck-z4cv
 - herdr-pluck-gz33
 - herdr-pluck-vhdh
+- herdr-pluck-1iof
 ---
 
 ## Context
@@ -27,7 +28,8 @@ The interaction is copy-only and keyboard-only. Exact fixed-width hint entry cop
 ## Dependencies
 - Blocked by `herdr-pluck-obnm` for pattern matching and deduplication.
 - Blocked by `herdr-pluck-94xq` for fixed-width hint assignment and lookup.
-- Blocked by `herdr-pluck-z4cv` for overlay rendering output.
+- Blocked by `herdr-pluck-z4cv` for abstract overlay rendering output.
+- Blocked by `herdr-pluck-1iof` for terminal smoke output before full picker input/copy wiring.
 - Blocked by `herdr-pluck-gz33` for clipboard copy execution.
 - Blocked by `herdr-pluck-vhdh` for target pane read/layout integration.
 

--- a/.ish/herdr-pluck-z4cv--implement-inline-overlay-renderer.md
+++ b/.ish/herdr-pluck-z4cv--implement-inline-overlay-renderer.md
@@ -1,14 +1,14 @@
 ---
 # herdr-pluck-z4cv
 title: Implement inline overlay renderer
-status: todo
+status: completed
 type: task
 priority: high
 tags:
 - pluck
 - renderer
 created_at: 2026-06-19T03:15:58.194704Z
-updated_at: 2026-06-19T03:21:41.655210Z
+updated_at: 2026-06-19T23:29:24.191690Z
 parent: herdr-pluck-t3sf
 blocked_by:
 - herdr-pluck-obnm
@@ -42,3 +42,49 @@ Use tmux-fingers destructive inline rendering as prior art. Online repo: https:/
 
 - [`src/fingers/match_formatter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/match_formatter.cr)
 - Related hint/match data behavior: [`src/fingers/hinter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/hinter.cr)
+
+
+
+## Design Decisions
+- Public renderer API should accept raw logical lines, `HintAssignments`, width, and height, returning abstract styled `Vec<RenderLine>`; terminal emission is deferred to `herdr-pluck-1iof`.
+- Keep renderer-specific intermediate types private to `src/renderer.rs`; only promote types to `src/model.rs` when they are stable cross-module domain types.
+- Rename `RenderStyle::Dim` to semantic `RenderStyle::Unmatched`; terminal smoke output can later map it to dim/black/gray presentation.
+- Render all provided recent unwrapped logical lines, manually wrap styled content to pane width, then crop to the final `height` rows for bottom-live-viewport behavior.
+- If wrapped content has fewer than `height` rows, top-pad with blank `Unmatched` rows. Return exactly `height` rows and pad each row to exactly `width` columns when dimensions are non-zero.
+- If `width == 0` or `height == 0`, return an empty vector. Avoid renderer panics/errors.
+- Hint replacement is destructive: the hint replaces the first `hint.chars().count()` characters of the matched substring; the remaining matched text stays `Match`. Renderer uses assignment hints exactly as provided; fixed-width semantics belong to `hints`.
+- Built-in matches are effectively ASCII/single-column for v1. Use `MatchSpan` UTF-8 byte offsets; use display-width wrapping where practical, but do not build a full grapheme/cell engine.
+- Trust upstream pattern/hint modules for overlap resolution, duplicate hint reuse, and fixed-width assignment. Renderer may sort occurrences by line/start for deterministic output but should not re-resolve overlaps.
+- Silently ignore out-of-bounds occurrence lines, invalid byte offsets, and duplicate exact occurrences beyond the first deterministic render. Do not clamp invalid ranges.
+- Treat matches shorter than hint width as a defensive edge case only; v1 built-ins should not normally produce them.
+- Merge adjacent output spans with the same `RenderStyle`; tests should assert normalized `(style, text)` tuples per row rather than verbose struct literals.
+
+
+
+## Implementation Notes
+- Added `renderer::render_inline_hints(logical_lines, assignments, width, height) -> Vec<RenderLine>` as the abstract renderer API for v1 picker output.
+- Renamed `RenderStyle::Dim` to semantic `RenderStyle::Unmatched`; terminal presentation remains deferred to the smoke-output follow-up.
+- Implemented private renderer occurrence collection/validation, destructive hint replacement, styled span construction, manual styled wrapping, bottom viewport cropping, top padding, fixed-width row padding, and adjacent span merging.
+- Renderer silently ignores out-of-bounds occurrence lines, invalid UTF-8 byte ranges, and duplicate exact occurrences after deterministic sorting.
+- Short-match defensive handling renders the matched text as `Match` without a hint; v1 built-ins are not expected to hit this path.
+- Existing overlay composition helpers were preserved and updated to use `Unmatched` style when flattening composed output.
+- Terminal/crossterm emission and Herdr-visible smoke rendering remain deferred to `herdr-pluck-1iof`.
+
+## Verification Results
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.
+- `ish check` passed.
+
+
+
+## Review Follow-up
+- Accepted PR review finding that `render_inline_hints` redundantly called `merge_render_line` after `wrap_styled_lines` had already normalized emitted rows.
+- Removed the extra merge pass and returned the cropped/padded visible rows directly, avoiding an unnecessary allocation per visible row.
+- Addressed the resulting clippy `let_and_return` cleanup.
+
+## Review Follow-up Verification
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.
+- `ish check` passed.

--- a/plans/1781838387-herdr-pluck-inline-hints.md
+++ b/plans/1781838387-herdr-pluck-inline-hints.md
@@ -1,0 +1,182 @@
+## Problem Statement
+
+Users migrating from tmux to Herdr lose the fast “visible terminal pluck” workflow provided by tmux-fingers: press a key, see short inline key hints over interesting strings in the current terminal viewport, type the hint, and have that string copied immediately. Herdr has normal mouse selection and keyboard copy mode, but those workflows are slower when the target is a URL, file path, SHA, UUID, IP address, or other recognizable token visible somewhere in a pane.
+
+The user wants a Herdr-native plugin that restores the core tmux-fingers copy workflow without attempting to clone tmux-fingers completely. The initial scope is copy-only: show inline hints for matched patterns in the live bottom viewport, accept a keyboard hint, copy the selected pattern via available system clipboard tools, and close immediately.
+
+## Solution
+
+Build a Rust-based Herdr plugin, tentatively named Herdr Pluck, that provides an interactive overlay picker. A Herdr keybinding invokes a plugin action. That action captures the originally focused pane id and opens a Herdr plugin overlay pane, explicitly passing the original pane id into the picker process. The picker reads the live bottom viewport as unwrapped recent text, obtains the target pane dimensions from Herdr layout APIs, scans hardcoded built-in regex patterns, assigns fixed-width keyboard hints, manually wraps the rendered logical lines to the target pane width, and displays a monochrome inline hint view.
+
+The overlay renders non-matched text dim/black, full matched text white, and destructive inline hint characters cyan. Users type the displayed fixed-width hint to copy the corresponding matched text. Successful copy exits the overlay immediately. Escape and Ctrl-C cancel. Enter does nothing. Invalid fixed-width hints clear the input buffer.
+
+The plugin uses a system-available clipboard fallback chain for v1. OSC52, custom regex configuration, richer actions, mouse support, and exact support for non-bottom scrolled viewports are deferred.
+
+## User Stories
+
+1. As a Herdr user migrating from tmux, I want to press a key to show copy hints over visible terminal strings, so that I can preserve my tmux-fingers workflow.
+2. As a Herdr user, I want the picker to work inside a Herdr pane, so that I do not need tmux to copy visible patterns quickly.
+3. As a Herdr user, I want the plugin to inspect the pane that was focused before the overlay opened, so that the picker targets the correct pane.
+4. As a Herdr user, I want the picker to appear as an overlay, so that I keep visual context while selecting a string.
+5. As a Herdr user, I want matched strings to be shown inline in a pane-like rendering, so that I can select items spatially rather than from a separate list.
+6. As a Herdr user, I want the overlay to use a monochrome copy of the pane, so that the hint UI is clear and implementation complexity remains low.
+7. As a Herdr user, I want non-matched text dimmed or black, so that matched strings stand out.
+8. As a Herdr user, I want matched strings rendered white, so that I can quickly see every selectable target.
+9. As a Herdr user, I want hint characters rendered cyan, so that the keys I need to type are visually obvious.
+10. As a Herdr user, I want hints to destructively replace the beginning of the matched text, so that the pane geometry remains stable.
+11. As a Herdr user, I want the plugin to find URLs, so that I can quickly copy visible links.
+12. As a Herdr user, I want the plugin to find file paths, so that I can quickly copy paths from compiler output, test failures, git output, and logs.
+13. As a Herdr user, I want the plugin to find Git SHAs, so that I can quickly copy commit hashes.
+14. As a Herdr user, I want the plugin to find UUIDs, so that I can quickly copy identifiers from logs.
+15. As a Herdr user, I want the plugin to find IPv4 addresses, so that I can quickly copy visible network addresses.
+16. As a Herdr user, I want the plugin to find long numeric identifiers, so that I can quickly copy issue numbers, ports, IDs, and other numeric tokens.
+17. As a Herdr user, I want pattern conflicts to resolve predictably, so that the full URL is selected instead of a smaller SHA or path inside it.
+18. As a Herdr user, I want higher-priority patterns to win over lower-priority overlapping patterns, so that useful larger tokens are preferred.
+19. As a Herdr user, I want longer matches to win within a priority level, so that more complete strings are copied.
+20. As a Herdr user, I want leftmost/topmost matches to win when all else is equal, so that hint assignment is deterministic.
+21. As a Herdr user, I want duplicate matched text to share the same hint, so that repeated identical tokens do not waste hint capacity.
+22. As a Herdr user, I want the same hint rendered at every duplicate occurrence, so that any visible occurrence communicates the same copy action.
+23. As a Herdr user, I want copied text to be based on the selected match text, not its screen position, so that duplicates behave naturally in copy-only mode.
+24. As a Herdr user, I want hints assigned top-to-bottom and left-to-right, so that hint placement is predictable.
+25. As a Herdr user, I want ergonomic home-row-ish hint letters, so that common selections are fast to type.
+26. As a Herdr user, I want all lowercase letters available as hints, so that the hint space is maximized.
+27. As a Herdr user, I want fixed-width hints, so that the picker never has ambiguous prefixes.
+28. As a Herdr user, I want one-character hints when there are few matches, so that selection is fast.
+29. As a Herdr user, I want two-character hints when there are more matches, so that the picker can cover a full busy viewport.
+30. As a Herdr user, I want v1 to cap at two-character hints, so that the interaction remains usable.
+31. As a Herdr user, I want excessive matches silently capped, so that v1 stays simple and avoids noisy warnings.
+32. As a Herdr user, I want matches shorter than the hint width ignored, so that hints do not overwrite unrelated text.
+33. As a Herdr user, I want the plugin to handle terminal soft wrapping, so that long URLs and paths can be copied even when they wrap on screen.
+34. As a Herdr user, I want matching to operate on unwrapped logical lines, so that wrapped strings are treated as one copyable target.
+35. As a Herdr user, I want rendering to wrap manually to the target pane width, so that the overlay lines align reasonably with the original pane.
+36. As a Herdr user, I want the plugin to focus on the live bottom viewport, so that it matches my normal “copy what I just saw” workflow.
+37. As a Herdr user, I want scrolled-back viewport support to be out of v1 scope, so that the initial plugin can be implemented quickly.
+38. As a Herdr user, I want the plugin to read enough recent unwrapped lines to reconstruct the live bottom viewport, so that soft-wrapped matches work.
+39. As a Herdr user, I want the plugin to use Herdr pane layout dimensions, so that wrapping and cropping use the actual target pane size.
+40. As a Herdr user, I want typing an exact hint to copy immediately, so that the workflow is fast.
+41. As a Herdr user, I want the overlay to close immediately after a successful copy, so that I return to my work without extra confirmation.
+42. As a Herdr user, I want Escape to cancel, so that I can leave the picker quickly.
+43. As a Herdr user, I want Ctrl-C to cancel, so that common terminal cancellation muscle memory works.
+44. As a Herdr user, I want Enter to be ignored, so that fixed-width hints remain self-submitting and simple.
+45. As a Herdr user, I want invalid fixed-width hints to clear the input buffer, so that I can recover from mistypes without restarting the picker.
+46. As a Herdr user, I want no mouse support in v1, so that the plugin remains focused on key-hint copying.
+47. As a Herdr user on macOS, I want copying to use available platform tools, so that selected text reaches my system clipboard.
+48. As a Herdr user on Linux Wayland, I want copying to use available Wayland clipboard tools when present, so that selected text reaches my clipboard.
+49. As a Herdr user on Linux X11, I want copying to use common X11 clipboard tools when present, so that selected text reaches my clipboard.
+50. As a Herdr user, I want a clear failure if no clipboard tool is available, so that I know why the copy did not complete.
+51. As a Herdr user, I want OSC52 deferred, so that v1 avoids terminal-specific clipboard complexity.
+52. As a plugin developer, I want the Herdr integration isolated behind an adapter, so that matching and rendering can be tested without a running Herdr instance.
+53. As a plugin developer, I want the pattern engine isolated, so that overlap resolution, named captures, and deduplication are easy to test.
+54. As a plugin developer, I want the hint engine isolated, so that hint width, cap behavior, and duplicate mapping are easy to test.
+55. As a plugin developer, I want the renderer isolated, so that wrapping and style segmentation can be tested independently of terminal input.
+56. As a plugin developer, I want the clipboard adapter isolated, so that fallback selection can be tested without writing to the actual clipboard.
+57. As a plugin developer, I want the CLI entrypoint separated from core logic, so that action-opening and picker behavior remain understandable.
+58. As a future user of custom regexes, I want the matcher model to support a named capture called match, so that custom patterns can copy only the useful substring.
+59. As a future user of custom regexes, I want v1 architecture to anticipate user-defined patterns, so that config support can follow without a rewrite.
+60. As a maintainer, I want Rust to produce a single shippable binary, so that plugin installation and distribution stay simple.
+
+## Implementation Decisions
+
+- The plugin will be implemented in Rust.
+- The plugin will use Herdr's plugin system with a keybound plugin action and a declared plugin overlay pane.
+- The keybinding invokes a plugin action rather than launching the picker directly, because the action can capture the originally focused pane before the overlay changes focus.
+- The action will pass the original target pane id to the overlay picker through an explicit environment variable.
+- The picker will inspect the target pane id from that explicit environment variable, not from the current focused pane.
+- The plugin will use Herdr CLI calls through the Herdr-provided binary path rather than binding to private Herdr internals.
+- The picker will obtain target pane dimensions from Herdr layout information.
+- The picker will read live bottom viewport content using recent unwrapped terminal text with a line count derived from target pane height.
+- The plugin will target the live bottom viewport only in v1.
+- Exact scrolled viewport support is out of scope for v1.
+- Matching will operate on unwrapped logical lines to support soft-wrapped URLs and paths.
+- Rendering will manually wrap styled spans to the target pane width rather than relying on terminal auto-wrap.
+- The overlay will render a monochrome pane-like view rather than preserving original ANSI styling.
+- Non-matches will render black or dim.
+- Matched text will render white.
+- Hint characters will render cyan.
+- Hints will destructively replace the beginning of the copied/highlighted match region.
+- Matches shorter than the fixed hint width will be ignored.
+- The initial pattern set will be hardcoded built-ins.
+- User-defined regex configuration will be anticipated architecturally but not included in v1.
+- Pattern priority will be applied before match length and position.
+- Overlapping matches will be rejected after accepting higher-priority, longer, earlier matches.
+- The initial priority order will prefer URLs, then file paths, then UUIDs, then Git SHAs, then IPv4 addresses, then long numeric identifiers.
+- A named capture called match will define the copied/highlighted substring when present; otherwise the full regex match will be used.
+- Duplicate copied text will share one hint.
+- The same hint will be rendered at every visible duplicate occurrence.
+- Hint assignment will follow the first visible occurrence of each unique copied text in top-to-bottom, left-to-right order.
+- The hint alphabet will be home-row-ish: home row letters first, then top row, then bottom row, with no excluded letters.
+- Hints will be fixed-width.
+- The plugin will use one-character hints when possible and two-character hints otherwise.
+- The plugin will cap v1 hinting at two-character hints, yielding a maximum of 676 unique copied texts.
+- Matches beyond the v1 hint cap will be silently omitted.
+- Input will be keyboard-only.
+- Exact hint entry will copy and exit immediately.
+- Invalid fixed-width hint entry will clear the input buffer and continue.
+- Escape and Ctrl-C will cancel the picker.
+- Enter will be ignored.
+- A successful copy will close the overlay immediately.
+- Clipboard behavior will use a system-available tool fallback chain.
+- OSC52 clipboard support is deferred.
+- A Herdr adapter module will encapsulate plugin context parsing, pane layout retrieval, pane reading, and overlay launching.
+- A pattern engine module will encapsulate hardcoded pattern definitions, priority handling, overlap rejection, named capture handling, and deduplication.
+- A hint engine module will encapsulate alphabet ordering, fixed-width selection, cap behavior, and hint mapping.
+- A renderer module will encapsulate monochrome styling, destructive hints, manual wrapping, and viewport cropping.
+- An input loop module will encapsulate raw terminal mode, hint collection, cancellation, invalid input behavior, and exit behavior.
+- A clipboard adapter module will encapsulate platform tool detection and copy execution.
+- A CLI entrypoint module will provide at least two modes: one to open the overlay for the current target pane, and one to run the picker inside the overlay.
+
+## Testing Decisions
+
+- Tests should focus on external behavior and stable module contracts, not private implementation details.
+- The pattern engine should have unit tests for built-in matching, priority order, longest-match selection, leftmost tie-breaking, overlap rejection, named capture behavior, duplicate text handling, and match cap preparation.
+- The hint engine should have unit tests for fixed-width selection, one-character and two-character hint generation, maximum capacity behavior, deterministic ordering, and duplicate text mapping.
+- The renderer should have unit tests for destructive hint replacement, match/non-match/hint style segmentation, manual wrapping to pane width, viewport height cropping, and behavior when matches are shorter than hint width.
+- The clipboard adapter should have tests for fallback command selection and error reporting using faked command availability; tests should not require writing to the real system clipboard.
+- The Herdr adapter should be designed so tests can use faked command responses rather than requiring a live Herdr server.
+- The input loop should be tested at the behavior level where practical: exact hint triggers copy action, invalid hint clears input, Escape cancels, Ctrl-C cancels, and Enter is ignored.
+- End-to-end tests against a live Herdr instance are not required for the first implementation, but the architecture should not preclude adding them later.
+- Good tests should validate observable inputs and outputs: given pane text, dimensions, patterns, and user keystrokes, the plugin should produce expected rendered state and copy decisions.
+- Existing prior art includes Herdr's own CLI/socket API shape for pane layout and pane read behavior, and tmux-fingers' behavior for joined wrapped lines and destructive inline hints.
+
+## Out of Scope
+
+- Non-copy actions such as open, paste, or jump mode.
+- Mouse support.
+- Preserving original pane ANSI colors and styles.
+- Exact current scrolled viewport support.
+- A native Herdr cell-overlay API.
+- A Herdr-native clipboard or buffer API.
+- OSC52 clipboard support.
+- User-defined regex configuration in v1.
+- Runtime plugin action registration.
+- Native non-terminal plugin UI.
+- Multi-select mode.
+- Fuzzy finding or list-based picking.
+- Configurable hint alphabet in v1.
+- Configurable pattern priority in v1.
+- Three-character or variable-length hints in v1.
+- Warnings for omitted matches beyond the 676-match cap.
+- Windows support unless it falls out naturally from the chosen Rust and command abstractions.
+
+## Further Notes
+
+The feature intentionally focuses on the highest-value tmux-fingers behavior: copy a visible pattern quickly by typing a short hint. The design borrows tmux-fingers' core trick for wrapped lines: match on unwrapped logical text, then render back into a same-width view so wrapping appears naturally. In Herdr, the closest v1 approximation is reading recent unwrapped bottom text using the target pane height, then manually wrapping in the plugin overlay.
+
+The architecture should keep the matching, hinting, rendering, input, clipboard, and Herdr integration concerns separate. Those deep modules should make v1 easier to test and should make the near-term addition of user-defined regexes straightforward.
+
+### Technical References
+
+These references preserve important implementation context discovered while researching Herdr and tmux-fingers. They are not product requirements, but they should be useful during implementation.
+
+- Herdr repository: https://github.com/ogulcancelik/herdr
+- tmux-fingers repository: https://github.com/Morantron/tmux-fingers
+- Herdr plugin authoring model: [`website/src/content/docs/plugins.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/plugins.mdx). Key points: plugins are manifest-declared executable commands; there is no separate SDK; plugins call back through the Herdr CLI/socket API; plugin panes support `overlay` placement; plugin commands receive Herdr/plugin context environment.
+- Herdr CLI reference: [`website/src/content/docs/cli-reference.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/cli-reference.mdx). Key points: `pane read` supports `visible`, `recent`, `recent-unwrapped`, and `detection`; `plugin pane open` supports `overlay`; custom keybindings can invoke `plugin_action`.
+- Herdr socket/API overview: [`website/src/content/docs/socket-api.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/socket-api.mdx). Key points: pane APIs include `pane.layout`, `pane.read`, and plugin pane methods; `recent-unwrapped` is documented as the source that ignores soft wrapping.
+- Herdr keybinding docs: [`website/src/content/docs/configuration.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/configuration.mdx). Key point: `[[keys.command]]` with `type = "plugin_action"` is the intended keybinding path for installed plugin actions.
+- Herdr pane schema: [`src/api/schema/panes.rs`](https://github.com/ogulcancelik/herdr/blob/main/src/api/schema/panes.rs). Key point: `PaneLayoutSnapshot` contains `PaneLayoutPane.rect`, and `PaneLayoutRect` includes `width` and `height`, which the picker can use for read line count and manual wrapping.
+- Herdr terminal read implementation: [`src/pane/terminal.rs`](https://github.com/ogulcancelik/herdr/blob/main/src/pane/terminal.rs). Key points: `visible_text` is built from rendered row cells; `recent_unwrapped` uses Ghostty `read_text_screen(..., unwrap)` behavior, making it the closest public equivalent to tmux `capture-pane -J` for bottom-viewport use.
+- tmux-fingers pane capture flow: [`src/fingers/commands/start.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/commands/start.cr) and [`src/tmux.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/tmux.cr). Key point: normal copy mode calls `capture-pane -J`, joining wrapped lines before matching; jump mode does not join.
+- tmux-fingers matching/hinting: [`src/fingers/hinter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/hinter.cr). Key points: matching runs against joined logical lines; duplicate text can reuse hints; named capture `match` is used as the copied/highlighted substring; hints longer than the highlighted text are skipped.
+- tmux-fingers destructive rendering: [`src/fingers/match_formatter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/match_formatter.cr). Key point: the hint replaces/chops part of the highlighted text rather than inserting extra columns, preserving geometry.
+- tmux-fingers clipboard behavior: [`src/fingers/action_runner.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/action_runner.cr) and [`src/tmux.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/tmux.cr). Key points: tmux-fingers writes to the tmux buffer, optionally uses tmux `load-buffer -w`, and for system copy shells out through available tools such as `pbcopy`, `wl-copy`, `xclip`, and `xsel`.

--- a/src/model.rs
+++ b/src/model.rs
@@ -87,6 +87,7 @@ impl SourceGeometrySnapshot {
     }
 }
 
+/// Unwrapped logical pane text lines and dimensions at the time of picker activation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaneText {
     pub lines: Vec<String>,
@@ -132,17 +133,20 @@ pub struct HintAssignment {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RenderStyle {
-    Dim,
+    Unmatched,
     Match,
     Hint,
 }
 
+/// A contiguous span of text to render in the picker, with a single style.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RenderSpan {
     pub text: String,
     pub style: RenderStyle,
 }
 
+/// A single line of text to render in the picker,
+/// with style spans for matched/highlighted regions.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RenderLine {
     pub spans: Vec<RenderSpan>,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,21 +1,252 @@
-use crate::model::{HintAssignment, Rect, RenderLine, RenderSpan, RenderStyle};
+use crate::hints::HintAssignments;
+use crate::model::{MatchSpan, Rect, RenderLine, RenderSpan, RenderStyle};
+use std::collections::HashSet;
+use unicode_width::UnicodeWidthChar;
 
-pub fn render_placeholder(assignments: &[HintAssignment]) -> Vec<RenderLine> {
-    assignments
+/// Renders logical pane lines as a fixed-size styled viewport with destructive inline hints.
+pub fn render_inline_hints(
+    logical_lines: &[String],
+    assignments: &HintAssignments,
+    width: u16,
+    height: u16,
+) -> Vec<RenderLine> {
+    if width == 0 || height == 0 {
+        return Vec::new();
+    }
+
+    let width = width as usize;
+    let height = height as usize;
+    let occurrences = collect_occurrences(logical_lines, assignments);
+    let styled_lines = build_styled_logical_lines(logical_lines, &occurrences);
+    let mut wrapped = wrap_styled_lines(&styled_lines, width);
+
+    if wrapped.is_empty() {
+        wrapped.push(blank_line(width));
+    }
+
+    if wrapped.len() > height {
+        wrapped.split_off(wrapped.len() - height)
+    } else {
+        let mut padded = Vec::with_capacity(height);
+        padded.extend((0..height - wrapped.len()).map(|_| blank_line(width)));
+        padded.extend(wrapped);
+        padded
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenderOccurrence {
+    line: usize,
+    start: usize,
+    end: usize,
+    hint: String,
+}
+
+fn collect_occurrences(
+    logical_lines: &[String],
+    assignments: &HintAssignments,
+) -> Vec<RenderOccurrence> {
+    let mut occurrences = Vec::new();
+
+    for assignment in assignments.assignments() {
+        for occurrence in &assignment.occurrences {
+            if is_valid_occurrence(logical_lines, occurrence) {
+                occurrences.push(RenderOccurrence {
+                    line: occurrence.line,
+                    start: occurrence.start,
+                    end: occurrence.end,
+                    hint: assignment.hint.clone(),
+                });
+            }
+        }
+    }
+
+    occurrences.sort_by(|left, right| {
+        (left.line, left.start, left.end).cmp(&(right.line, right.start, right.end))
+    });
+
+    let mut seen = HashSet::new();
+    occurrences
+        .into_iter()
+        .filter(|occurrence| seen.insert((occurrence.line, occurrence.start, occurrence.end)))
+        .collect()
+}
+
+fn is_valid_occurrence(logical_lines: &[String], occurrence: &MatchSpan) -> bool {
+    let Some(line) = logical_lines.get(occurrence.line) else {
+        return false;
+    };
+
+    occurrence.start <= occurrence.end
+        && occurrence.end <= line.len()
+        && line.is_char_boundary(occurrence.start)
+        && line.is_char_boundary(occurrence.end)
+}
+
+/// Builds styled render lines from logical lines and their matched occurrences, applying destructive hints.
+fn build_styled_logical_lines(
+    logical_lines: &[String],
+    occurrences: &[RenderOccurrence],
+) -> Vec<RenderLine> {
+    logical_lines
         .iter()
-        .map(|assignment| RenderLine {
-            spans: vec![
-                RenderSpan {
-                    text: assignment.hint.clone(),
-                    style: RenderStyle::Hint,
-                },
-                RenderSpan {
-                    text: assignment.text.clone(),
-                    style: RenderStyle::Match,
-                },
-            ],
+        .enumerate()
+        .map(|(line_index, line)| {
+            let mut spans = Vec::new();
+            let mut cursor = 0;
+
+            for occurrence in occurrences
+                .iter()
+                .filter(|occurrence| occurrence.line == line_index)
+            {
+                if occurrence.start < cursor {
+                    continue;
+                }
+
+                push_span(
+                    &mut spans,
+                    &line[cursor..occurrence.start],
+                    RenderStyle::Unmatched,
+                );
+                push_destructive_hint_spans(
+                    &mut spans,
+                    &line[occurrence.start..occurrence.end],
+                    occurrence,
+                );
+                cursor = occurrence.end;
+            }
+
+            push_span(&mut spans, &line[cursor..], RenderStyle::Unmatched);
+            RenderLine { spans }
         })
         .collect()
+}
+
+/// Pushes spans for a matched occurrence, replacing the match prefix with the hint if the hint is shorter.
+fn push_destructive_hint_spans(
+    spans: &mut Vec<RenderSpan>,
+    matched_text: &str,
+    occurrence: &RenderOccurrence,
+) {
+    let hint_width = occurrence.hint.chars().count();
+    let Some(remainder_start) = byte_index_after_chars(matched_text, hint_width) else {
+        push_span(spans, matched_text, RenderStyle::Match);
+        return;
+    };
+
+    push_span(spans, &occurrence.hint, RenderStyle::Hint);
+    push_span(spans, &matched_text[remainder_start..], RenderStyle::Match);
+}
+
+/// Returns the byte index immediately after the specified number of chars, or None if the text has fewer chars.
+fn byte_index_after_chars(text: &str, count: usize) -> Option<usize> {
+    if count == 0 {
+        return Some(0);
+    }
+
+    text.char_indices()
+        .nth(count)
+        .map(|(index, _)| index)
+        .or_else(|| (text.chars().count() == count).then_some(text.len()))
+}
+
+// Wraps styled lines to a given width, preserving styles and padding short lines with spaces.
+fn wrap_styled_lines(lines: &[RenderLine], width: usize) -> Vec<RenderLine> {
+    if lines.is_empty() {
+        return Vec::new();
+    }
+
+    let mut wrapped = Vec::new();
+
+    for line in lines {
+        let mut current = RenderLine { spans: Vec::new() };
+        let mut current_width = 0;
+        let mut saw_content = false;
+
+        for span in &line.spans {
+            for ch in span.text.chars() {
+                saw_content = true;
+                let char_width = ch.width().unwrap_or(0);
+                if current_width > 0 && current_width + char_width > width {
+                    pad_line(&mut current, width, current_width);
+                    wrapped.push(merge_render_line(current));
+                    current = RenderLine { spans: Vec::new() };
+                    current_width = 0;
+                }
+
+                push_char(&mut current.spans, ch, span.style);
+                current_width += char_width;
+
+                if current_width == width {
+                    wrapped.push(merge_render_line(current));
+                    current = RenderLine { spans: Vec::new() };
+                    current_width = 0;
+                }
+            }
+        }
+
+        if !current.spans.is_empty() || !saw_content {
+            pad_line(&mut current, width, current_width);
+            wrapped.push(merge_render_line(current));
+        }
+    }
+
+    wrapped
+}
+
+/// Pads the line with spaces to reach the target width, if it's currently shorter.
+fn pad_line(line: &mut RenderLine, width: usize, current_width: usize) {
+    if current_width < width {
+        push_span(
+            &mut line.spans,
+            &" ".repeat(width - current_width),
+            RenderStyle::Unmatched,
+        );
+    }
+}
+
+/// Creates a blank line of the specified width with unmatched style.
+fn blank_line(width: usize) -> RenderLine {
+    RenderLine {
+        spans: vec![RenderSpan {
+            text: " ".repeat(width),
+            style: RenderStyle::Unmatched,
+        }],
+    }
+}
+
+/// Pushes a single character as a span, merging with the previous span if styles match.
+fn push_char(spans: &mut Vec<RenderSpan>, ch: char, style: RenderStyle) {
+    let mut buffer = [0; 4];
+    push_span(spans, ch.encode_utf8(&mut buffer), style);
+}
+
+/// Pushes a text span into the line, merging with the previous span if styles match.
+fn push_span(spans: &mut Vec<RenderSpan>, text: &str, style: RenderStyle) {
+    if text.is_empty() {
+        return;
+    }
+
+    if let Some(last) = spans.last_mut() {
+        if last.style == style {
+            last.text.push_str(text);
+            return;
+        }
+    }
+
+    spans.push(RenderSpan {
+        text: text.to_string(),
+        style,
+    });
+}
+
+/// Merges adjacent spans with the same style into a single span.
+fn merge_render_line(line: RenderLine) -> RenderLine {
+    let mut spans = Vec::new();
+    for span in line.spans {
+        push_span(&mut spans, &span.text, span.style);
+    }
+    RenderLine { spans }
 }
 
 /// Places source-sized text into an overlay-local viewport, padding or clipping as needed.
@@ -65,12 +296,13 @@ pub fn compose_render_lines_into_overlay(
     .map(|text| RenderLine {
         spans: vec![RenderSpan {
             text,
-            style: RenderStyle::Dim,
+            style: RenderStyle::Unmatched,
         }],
     })
     .collect()
 }
 
+/// Flattens a render line into plain text by concatenating its spans, ignoring styles.
 fn flatten_render_line(line: &RenderLine) -> String {
     line.spans.iter().map(|span| span.text.as_str()).collect()
 }
@@ -78,25 +310,236 @@ fn flatten_render_line(line: &RenderLine) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::MatchSpan;
+    use crate::hints::assign_hints;
+    use crate::model::HintAssignment;
+
+    fn span(text: impl Into<String>, line: usize, start: usize) -> MatchSpan {
+        let text = text.into();
+        MatchSpan {
+            line,
+            start,
+            end: start + text.len(),
+            text,
+            pattern: "test".to_string(),
+            priority: 10,
+        }
+    }
+
+    fn assignment(hint: &str, text: &str, occurrences: Vec<MatchSpan>) -> HintAssignment {
+        HintAssignment {
+            hint: hint.to_string(),
+            text: text.to_string(),
+            occurrences,
+        }
+    }
+
+    fn assert_rows(lines: &[RenderLine], expected: &[&[(RenderStyle, &str)]]) {
+        let actual: Vec<Vec<(RenderStyle, &str)>> = lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| (span.style, span.text.as_str()))
+                    .collect()
+            })
+            .collect();
+        let expected: Vec<Vec<(RenderStyle, &str)>> =
+            expected.iter().map(|row| row.to_vec()).collect();
+
+        assert_eq!(actual, expected);
+    }
 
     #[test]
-    fn placeholder_renderer_emits_hint_and_match_spans() {
-        let lines = render_placeholder(&[HintAssignment {
-            hint: "a".to_string(),
-            text: "https://example.com".to_string(),
-            occurrences: vec![MatchSpan {
+    fn zero_dimensions_return_no_rows() {
+        let assignments = HintAssignments::new(Vec::new());
+
+        assert!(render_inline_hints(&["abc".to_string()], &assignments, 0, 3).is_empty());
+        assert!(render_inline_hints(&["abc".to_string()], &assignments, 3, 0).is_empty());
+    }
+
+    #[test]
+    fn empty_input_returns_blank_viewport() {
+        let assignments = HintAssignments::new(Vec::new());
+        let rows = render_inline_hints(&[], &assignments, 4, 2);
+
+        assert_rows(
+            &rows,
+            &[
+                &[(RenderStyle::Unmatched, "    ")],
+                &[(RenderStyle::Unmatched, "    ")],
+            ],
+        );
+    }
+
+    #[test]
+    fn destructive_hint_replaces_match_prefix() {
+        let lines = vec!["foo bar baz".to_string()];
+        let assignments =
+            HintAssignments::new(vec![assignment("a", "bar", vec![span("bar", 0, 4)])]);
+
+        let rows = render_inline_hints(&lines, &assignments, 11, 1);
+
+        assert_rows(
+            &rows,
+            &[&[
+                (RenderStyle::Unmatched, "foo "),
+                (RenderStyle::Hint, "a"),
+                (RenderStyle::Match, "ar"),
+                (RenderStyle::Unmatched, " baz"),
+            ]],
+        );
+    }
+
+    #[test]
+    fn duplicate_text_occurrences_render_same_hint() {
+        let lines = vec!["foo then foo".to_string()];
+        let assignments = assign_hints(vec![span("foo", 0, 0), span("foo", 0, 9)]);
+
+        let rows = render_inline_hints(&lines, &assignments, 12, 1);
+
+        assert_rows(
+            &rows,
+            &[&[
+                (RenderStyle::Hint, "a"),
+                (RenderStyle::Match, "oo"),
+                (RenderStyle::Unmatched, " then "),
+                (RenderStyle::Hint, "a"),
+                (RenderStyle::Match, "oo"),
+            ]],
+        );
+    }
+
+    #[test]
+    fn duplicate_exact_occurrence_is_rendered_once() {
+        let lines = vec!["foo".to_string()];
+        let assignments = HintAssignments::new(vec![assignment(
+            "a",
+            "foo",
+            vec![span("foo", 0, 0), span("foo", 0, 0)],
+        )]);
+
+        let rows = render_inline_hints(&lines, &assignments, 3, 1);
+
+        assert_rows(
+            &rows,
+            &[&[(RenderStyle::Hint, "a"), (RenderStyle::Match, "oo")]],
+        );
+    }
+
+    #[test]
+    fn wraps_styled_content_and_preserves_styles() {
+        let lines = vec!["xx abcdef yy".to_string()];
+        let assignments =
+            HintAssignments::new(vec![assignment("a", "abcdef", vec![span("abcdef", 0, 3)])]);
+
+        let rows = render_inline_hints(&lines, &assignments, 5, 3);
+
+        assert_rows(
+            &rows,
+            &[
+                &[
+                    (RenderStyle::Unmatched, "xx "),
+                    (RenderStyle::Hint, "a"),
+                    (RenderStyle::Match, "b"),
+                ],
+                &[(RenderStyle::Match, "cdef"), (RenderStyle::Unmatched, " ")],
+                &[(RenderStyle::Unmatched, "yy   ")],
+            ],
+        );
+    }
+
+    #[test]
+    fn crops_to_bottom_viewport_after_wrapping() {
+        let lines = vec!["one".to_string(), "two".to_string(), "three".to_string()];
+        let assignments = HintAssignments::new(Vec::new());
+
+        let rows = render_inline_hints(&lines, &assignments, 5, 2);
+
+        assert_rows(
+            &rows,
+            &[
+                &[(RenderStyle::Unmatched, "two  ")],
+                &[(RenderStyle::Unmatched, "three")],
+            ],
+        );
+    }
+
+    #[test]
+    fn top_pads_when_content_is_shorter_than_viewport() {
+        let lines = vec!["hi".to_string()];
+        let assignments = HintAssignments::new(Vec::new());
+
+        let rows = render_inline_hints(&lines, &assignments, 4, 3);
+
+        assert_rows(
+            &rows,
+            &[
+                &[(RenderStyle::Unmatched, "    ")],
+                &[(RenderStyle::Unmatched, "    ")],
+                &[(RenderStyle::Unmatched, "hi  ")],
+            ],
+        );
+    }
+
+    #[test]
+    fn invalid_occurrences_are_ignored() {
+        let lines = vec!["abc".to_string()];
+        let assignments = HintAssignments::new(vec![assignment(
+            "a",
+            "bad",
+            vec![
+                MatchSpan {
+                    end: 5,
+                    ..span("abc", 0, 0)
+                },
+                MatchSpan {
+                    line: 9,
+                    ..span("abc", 0, 0)
+                },
+            ],
+        )]);
+
+        let rows = render_inline_hints(&lines, &assignments, 3, 1);
+
+        assert_rows(&rows, &[&[(RenderStyle::Unmatched, "abc")]]);
+    }
+
+    #[test]
+    fn non_char_boundary_occurrence_is_ignored() {
+        let lines = vec!["éx".to_string()];
+        let assignments = HintAssignments::new(vec![assignment(
+            "a",
+            "bad",
+            vec![MatchSpan {
                 line: 0,
-                start: 0,
-                end: 19,
-                text: "https://example.com".to_string(),
-                pattern: "url".to_string(),
+                start: 1,
+                end: 2,
+                text: "bad".to_string(),
+                pattern: "test".to_string(),
                 priority: 10,
             }],
-        }]);
+        )]);
 
-        assert_eq!(lines[0].spans[0].style, RenderStyle::Hint);
-        assert_eq!(lines[0].spans[1].style, RenderStyle::Match);
+        let rows = render_inline_hints(&lines, &assignments, 3, 1);
+
+        assert_rows(&rows, &[&[(RenderStyle::Unmatched, "éx ")]]);
+    }
+
+    #[test]
+    fn short_match_renders_as_match_without_hint() {
+        let lines = vec!["x a y".to_string()];
+        let assignments = HintAssignments::new(vec![assignment("as", "a", vec![span("a", 0, 2)])]);
+
+        let rows = render_inline_hints(&lines, &assignments, 5, 1);
+
+        assert_rows(
+            &rows,
+            &[&[
+                (RenderStyle::Unmatched, "x "),
+                (RenderStyle::Match, "a"),
+                (RenderStyle::Unmatched, " y"),
+            ]],
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add abstract inline-hint renderer with destructive hint replacement and styled wrapping
- rename render style semantics from `Dim` to `Unmatched` and preserve overlay composition helpers
- handle bottom viewport cropping, top padding, fixed-width rows, invalid occurrence skipping, and duplicate occurrence normalization
- add renderer unit coverage and record follow-up Ish for terminal smoke output

## Verification
- cargo fmt --all -- --check
- cargo test --all-features
- cargo clippy --all-targets --all
- ish check