### PR TITLE
docs: finalize v1 packaging docs

### DIFF
--- a/.ish/herdr-pluck-clt9--finalize-plugin-packaging-and-v1-verification.md
+++ b/.ish/herdr-pluck-clt9--finalize-plugin-packaging-and-v1-verification.md
@@ -1,7 +1,7 @@
 ---
 # herdr-pluck-clt9
 title: Finalize plugin packaging and v1 verification
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
 - packaging
 - docs
 created_at: 2026-06-19T03:16:34.072605Z
-updated_at: 2026-06-19T03:21:41.665717Z
+updated_at: 2026-06-21T19:42:24.727901Z
 parent: herdr-pluck-t3sf
 blocked_by:
 - herdr-pluck-guwf
@@ -43,3 +43,23 @@ When finalizing docs and install instructions, verify the current Herdr plugin/k
 - [`website/src/content/docs/plugins.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/plugins.mdx)
 - [`website/src/content/docs/configuration.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/configuration.mdx)
 - [`website/src/content/docs/cli-reference.mdx`](https://github.com/ogulcancelik/herdr/blob/main/website/src/content/docs/cli-reference.mdx)
+
+
+## Implementation Notes
+- Rewrote `README.md` for plugin users/maintainers rather than implementation history.
+- Documented Herdr requirements, build/link/install steps, the manifest action id, a sample `plugin_action` keybinding, normal usage, supported built-in patterns, clipboard tool requirements, v1 behavior, and v1 limitations.
+- Verified `herdr-plugin.toml` remains checked in with plugin id `rmarganti.herdr-pluck` and action `pluck` invoking `./target/release/herdr-pluck open`.
+- Reviewed the delivered v1 behavior against the PRD user workflow: focus pane, invoke action, see inline hints for built-in patterns, type fixed-width hint to copy, cancel with Escape/Ctrl-C, and surface clipboard-tool requirements.
+
+## Verification Results
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.
+- `cargo build --release` passed.
+- `ish check` passed.
+- `herdr plugin link .` succeeded.
+- `herdr plugin action list --plugin rmarganti.herdr-pluck` showed action `pluck`.
+- Manual Herdr copy smoke: created a temporary source tab containing `https://example.com/herdr-pluck-final-1782073400`, `/tmp/herdr-pluck-final`, `abcdef1234567890`, `10.20.30.40`, and `9876543210`; invoked `herdr plugin action invoke rmarganti.herdr-pluck.pluck`; confirmed the temporary picker tab rendered inline hints; typed the visible URL hint; verified `pbpaste` contained `https://example.com/herdr-pluck-final-1782073400`; confirmed the picker tab closed and focus returned to the source tab.
+- Manual Herdr Escape smoke: invoked the plugin action again, sent Escape to the picker pane, and confirmed the temporary picker tab closed with focus restored.
+- Manual Herdr Ctrl-C smoke: invoked the plugin action again, sent Ctrl-C as the control character to the picker pane, and confirmed the temporary picker tab closed with focus restored.
+- Cleaned up the temporary smoke-test tab after verification.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,42 @@
 # Herdr Pluck
 
-Rust Herdr plugin for tmux-fingers-style inline hints over visible pane text.
+Herdr Pluck is a Herdr plugin for quickly copying visible terminal tokens with short keyboard hints, inspired by `tmux-fingers`.
 
-## Development
+Invoke the plugin while a pane is focused, type the displayed hint for the token you want, and the selected text is copied to your system clipboard. Escape or Ctrl-C cancels.
 
-```bash
-cargo build
-cargo test
-cargo fmt --all -- --check
-```
+## Requirements
 
-## Herdr plugin shape
+- Herdr 0.7.0 or newer
+- Rust/Cargo to build from source
+- A system clipboard command:
+  - macOS: `pbcopy`
+  - Linux Wayland: `wl-copy`
+  - Linux X11: `xclip` or `xsel`
 
-The plugin manifest is `herdr-plugin.toml`.
+## Install
 
-- Action: `rmarganti.herdr-pluck.pluck`
-- Production entrypoint: `herdr-pluck open`
-- Picker entrypoint: `herdr-pluck pick --snapshot PATH`
-- Binary: `herdr-pluck`
-
-During local development:
+From this checkout:
 
 ```bash
 cargo build --release
 herdr plugin link .
-herdr plugin action invoke rmarganti.herdr-pluck.pluck
 ```
 
-Suggested keybinding:
+Verify Herdr can see the action:
+
+```bash
+herdr plugin action list --plugin rmarganti.herdr-pluck
+```
+
+The action id is:
+
+```text
+rmarganti.herdr-pluck.pluck
+```
+
+## Keybinding
+
+Add a Herdr `plugin_action` binding to your Herdr config, choosing any free key you prefer:
 
 ```toml
 [[keys.command]]
@@ -37,15 +46,67 @@ command = "rmarganti.herdr-pluck.pluck"
 description = "pluck visible token"
 ```
 
-## Entrypoints
+Reload Herdr config after editing:
 
 ```bash
-herdr-pluck open [--target-pane PANE_ID]
-herdr-pluck pick --snapshot PATH
+herdr server reload-config
 ```
 
-The action entrypoint captures the originally focused pane, creates a temporary
-Herdr tab with the same split layout, launches picker mode in the corresponding
-temporary pane, and closes the temporary tab when the picker exits. The current
-picker is still a scaffold placeholder; full hint input and clipboard copy are
-follow-up work.
+## Usage
+
+1. Focus a Herdr pane containing a URL, path, commit SHA, UUID, IP address, or long numeric identifier.
+2. Invoke `rmarganti.herdr-pluck.pluck` through your keybinding or Herdr's plugin action command.
+3. Herdr Pluck opens a temporary picker tab that mirrors the source layout and shows hints over copyable text in the target pane.
+4. Type the shown one- or two-letter hint to copy that token and close the picker.
+5. Press Escape or Ctrl-C to cancel without copying.
+
+You can also invoke the action from the CLI:
+
+```bash
+herdr plugin action invoke rmarganti.herdr-pluck.pluck
+```
+
+## What gets matched
+
+Herdr Pluck v1 recognizes these built-in token types, in priority order:
+
+1. URLs
+2. File paths
+3. UUIDs
+4. Git SHAs
+5. IPv4 addresses
+6. Long numeric identifiers
+
+When identical text appears more than once, every visible occurrence shows the same hint and copies the same text.
+
+## Behavior and limits
+
+- Hints are keyboard-only and fixed-width: one character for small match sets, two characters for larger match sets.
+- Hint characters replace the beginning of matched text on screen so pane geometry stays aligned.
+- Matching is based on visible pane content and handles soft-wrapped tokens such as long URLs.
+- The picker renders a simplified view instead of preserving the source pane's original colors.
+- v1 supports up to 676 unique copied texts in one picker view.
+- Enter is ignored while the picker is active.
+- Invalid full-width hints clear the typed hint buffer so you can try again.
+
+## Not in v1
+
+- Mouse selection
+- OSC52 clipboard copying
+- Custom regex configuration
+- Non-copy actions such as opening URLs or jumping to text
+- Multi-select
+- Preserving original ANSI colors/styles
+- Windows support
+
+## Troubleshooting
+
+If invoking the action does nothing useful, check that the plugin is linked and the release binary exists:
+
+```bash
+cargo build --release
+herdr plugin link .
+herdr plugin action list --plugin rmarganti.herdr-pluck
+```
+
+If copying fails, install one of the supported clipboard tools for your platform and try again.


### PR DESCRIPTION
## Summary
- rewrite README around actual Herdr Pluck user install/usage flows
- document action id, keybinding setup, supported patterns, clipboard requirements, and v1 limits
- record final packaging/manual smoke verification in the completed Ish

## Verification
- cargo fmt --all -- --check
- cargo test --all-features
- cargo clippy --all-targets --all
- cargo build --release
- ish check
- manual Herdr copy, Escape cancel, and Ctrl-C cancel smoke tests