### PR TITLE
docs: add license file for v1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ryan Marganti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ When identical text appears more than once, every visible occurrence shows the s
 - Preserving original ANSI colors/styles
 - Windows support
 
+## License
+
+MIT; see [LICENSE](LICENSE).
+
 ## Troubleshooting
 
 If invoking the action does nothing useful, check that the plugin is linked and the release binary exists:


### PR DESCRIPTION
## Summary
- add the MIT license file declared by the crate metadata
- link the license from the README for v1 packaging completeness

## Verification
- cargo fmt --all -- --check
- cargo test --all-features
- cargo clippy --all-targets --all
- cargo build --release
