### PR TITLE
feat: wrap up Herdr Pluck v1

### DIFF
--- a/.ish/herdr-pluck-g57o--support-expanded-tmux-fingers-compatible-pattern-s.md
+++ b/.ish/herdr-pluck-g57o--support-expanded-tmux-fingers-compatible-pattern-s.md
@@ -1,7 +1,7 @@
 ---
 # herdr-pluck-g57o
 title: Support expanded tmux-fingers-compatible pattern set
-status: todo
+status: completed
 type: task
 priority: low
 tags:
@@ -9,7 +9,7 @@ tags:
 - matching
 - deferred
 created_at: 2026-06-19T18:34:14.319819Z
-updated_at: 2026-06-19T18:34:14.319819Z
+updated_at: 2026-06-21T19:49:17.627948Z
 parent: herdr-pluck-t3sf
 blocked_by:
 - herdr-pluck-obnm
@@ -31,3 +31,16 @@ Use tmux-fingers as prior art for additional built-ins, but do not blindly add p
 - Pattern tests cover every newly accepted class.
 - Existing v1 pattern behavior remains unchanged unless deliberately documented.
 - Project verification passes.
+
+
+## Implementation Notes
+- Expanded built-in matching toward tmux-fingers parity with always-enabled `hex`, `kubernetes`, `kubernetes-pod`, `git-status`, `git-status-branch`, and `diff` pattern classes.
+- Added named-capture support coverage for Git status, upstream branch, and diff paths so copied text excludes command/status prefixes.
+- Tuned Kubernetes resource boundaries to avoid common false positives such as `serviceable` while still matching resource references like `pod/nginx` and `deployment.apps/frontend`.
+- Documented the expanded always-enabled pattern set in `README.md`; configurable regex sets remain deferred/out of scope.
+
+## Verification Results
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.
+- `ish check` passed.

--- a/.ish/herdr-pluck-t3sf--herdr-pluck-inline-hints-v1.md
+++ b/.ish/herdr-pluck-t3sf--herdr-pluck-inline-hints-v1.md
@@ -1,14 +1,14 @@
 ---
 # herdr-pluck-t3sf
 title: Herdr Pluck inline hints v1
-status: todo
+status: completed
 type: milestone
 priority: high
 tags:
 - pluck
 - prd-1781838387
 created_at: 2026-06-19T03:15:21.064212Z
-updated_at: 2026-06-19T03:21:41.623915Z
+updated_at: 2026-06-21T19:49:17.670771Z
 ---
 
 ## Context
@@ -48,3 +48,14 @@ Important PRD reference files to inspect before implementation details:
 - tmux-fingers matching/hinting: [`src/fingers/hinter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/hinter.cr)
 - tmux-fingers destructive rendering: [`src/fingers/match_formatter.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/match_formatter.cr)
 - tmux-fingers clipboard behavior: [`src/fingers/action_runner.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/fingers/action_runner.cr) and [`src/tmux.cr`](https://github.com/Morantron/tmux-fingers/blob/master/src/tmux.cr)
+
+
+## Wrap-up Notes
+- All active child implementation ishes are completed, including final packaging/docs and expanded tmux-fingers-compatible pattern support.
+- Final verification passed for formatting, tests, clippy, and Ish graph validation.
+
+## Final Verification Results
+- `cargo fmt --all -- --check` passed.
+- `cargo test --all-features` passed.
+- `cargo clippy --all-targets --all` passed.
+- `ish check` passed.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ herdr server reload-config
 
 ## Usage
 
-1. Focus a Herdr pane containing a URL, path, commit SHA, UUID, IP address, or long numeric identifier.
+1. Focus a Herdr pane containing a URL, path, commit SHA, UUID, IP address, long numeric identifier, hex literal, Kubernetes reference, Git status path, branch, or diff path.
 2. Invoke `rmarganti.herdr-pluck.pluck` through your keybinding or Herdr's plugin action command.
 3. Herdr Pluck opens a temporary picker tab that mirrors the source layout and shows hints over copyable text in the target pane.
 4. Type the shown one- or two-letter hint to copy that token and close the picker.
@@ -68,14 +68,20 @@ herdr plugin action invoke rmarganti.herdr-pluck.pluck
 
 ## What gets matched
 
-Herdr Pluck v1 recognizes these built-in token types, in priority order:
+Herdr Pluck recognizes these built-in token types, in priority order:
 
 1. URLs
-2. File paths
-3. UUIDs
-4. Git SHAs
-5. IPv4 addresses
-6. Long numeric identifiers
+2. Git status paths, Git upstream branch names, and diff paths
+3. Kubernetes resource references such as `pod/nginx` or `deployment.apps/frontend`
+4. File paths
+5. UUIDs
+6. Deployment-managed Kubernetes pod names
+7. Git SHAs
+8. Hex literals such as `0xdeadBEEF`
+9. IPv4 addresses
+10. Long numeric identifiers
+
+The expanded pattern set is always enabled for v1.1-style compatibility with `tmux-fingers`; user-configurable regex sets remain out of scope for v1.
 
 When identical text appears more than once, every visible occurrence shows the same hint and copies the same text.
 

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -4,6 +4,8 @@ use std::sync::OnceLock;
 
 static BUILT_IN_PATTERNS: OnceLock<Vec<PatternDefinition>> = OnceLock::new();
 
+const KUBERNETES_RESOURCE_KINDS: &str = "deployment.app|binding|componentstatuse|configmap|endpoint|event|limitrange|namespace|node|persistentvolumeclaim|persistentvolume|pod|podtemplate|replicationcontroller|resourcequota|secret|serviceaccount|service|mutatingwebhookconfiguration.admissionregistration.k8s.io|validatingwebhookconfiguration.admissionregistration.k8s.io|customresourcedefinition.apiextension.k8s.io|apiservice.apiregistration.k8s.io|controllerrevision.apps|daemonset.apps|deployment.apps|replicaset.apps|statefulset.apps|tokenreview.authentication.k8s.io|localsubjectaccessreview.authorization.k8s.io|selfsubjectaccessreviews.authorization.k8s.io|selfsubjectrulesreview.authorization.k8s.io|subjectaccessreview.authorization.k8s.io|horizontalpodautoscaler.autoscaling|cronjob.batch|job.batch|certificatesigningrequest.certificates.k8s.io|events.events.k8s.io|daemonset.extensions|deployment.extensions|ingress.extensions|networkpolicies.extensions|podsecuritypolicies.extensions|replicaset.extensions|networkpolicie.networking.k8s.io|poddisruptionbudget.policy|clusterrolebinding.rbac.authorization.k8s.io|clusterrole.rbac.authorization.k8s.io|rolebinding.rbac.authorization.k8s.io|role.rbac.authorization.k8s.io|storageclasse.storage.k8s.io";
+
 #[derive(Debug)]
 struct PatternDefinition {
     name: &'static str,
@@ -46,13 +48,31 @@ fn built_in_patterns() -> &'static [PatternDefinition] {
                 10,
                 r#"((https?://|git@|git://|ssh://|ftp://|file:///)[^\s()"']+)"#,
             ),
+            PatternDefinition::compile("git-status", 15, r#"(modified|deleted|deleted by us|new file): +(?<match>.+)"#),
+            PatternDefinition::compile(
+                "git-status-branch",
+                15,
+                r#"Your branch is up to date with '(?<match>.*)'\."#,
+            ),
+            PatternDefinition::compile("diff", 15, r#"(---|\+\+\+) [ab]/(?<match>.*)"#),
+            PatternDefinition::compile(
+                "kubernetes",
+                18,
+                &format!(r#"\b({KUBERNETES_RESOURCE_KINDS})([/_#$%&+=@-][[:alnum:]_#$%&+=/@-]*)?\b"#),
+            ),
             PatternDefinition::compile("path", 20, r#"(([.\w\-~\$@]+)?(/[.\w\-@]+)+/?)"#),
             PatternDefinition::compile(
                 "uuid",
                 30,
                 r#"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"#,
             ),
+            PatternDefinition::compile(
+                "kubernetes-pod",
+                35,
+                r#"\b[a-z][a-z0-9-]*[a-z0-9]-[bcdfghjklmnpqrstvwxz2456789]{5,10}-[bcdfghjklmnpqrstvwxz2456789]{5}\b"#,
+            ),
             PatternDefinition::compile("git-sha", 40, r#"\b[0-9a-fA-F]{7,40}\b"#),
+            PatternDefinition::compile("hex", 45, r#"\b0x[0-9a-fA-F]+\b"#),
             PatternDefinition::compile("ipv4", 50, r#"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"#),
             PatternDefinition::compile("number", 60, r#"[0-9]{4,}"#),
         ]
@@ -263,6 +283,121 @@ mod tests {
             .collect();
 
         assert_eq!(numbers, vec!["1234", "5678", "9012"]);
+    }
+
+    #[test]
+    fn finds_hex_literals_before_numeric_submatches() {
+        let matches = find_matches(&lines(["values 0xdeadBEEF 0x1234 not0xabc"]));
+        let hexes: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "hex")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(hexes, vec!["0xdeadBEEF", "0x1234"]);
+        assert!(!matches
+            .iter()
+            .any(|span| span.pattern == "number" && span.text == "1234"));
+    }
+
+    #[test]
+    fn finds_kubernetes_resource_references() {
+        let matches = find_matches(&lines([
+            "kubectl get pod/nginx-123 service/api deployment.apps/frontend",
+        ]));
+        let resources: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "kubernetes")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(
+            resources,
+            vec!["pod/nginx-123", "service/api", "deployment.apps/frontend"]
+        );
+    }
+
+    #[test]
+    fn finds_deployment_managed_kubernetes_pod_names() {
+        let matches = find_matches(&lines([
+            "pods nginx-deployment-66b6c48dd5-7xb2r api-abcde-12345 bad-pod-abcde-aeiou",
+        ]));
+        let pods: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "kubernetes-pod")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(pods, vec!["nginx-deployment-66b6c48dd5-7xb2r"]);
+    }
+
+    #[test]
+    fn finds_git_status_paths_with_named_capture() {
+        let matches = find_matches(&lines([
+            "modified:   src/main.rs",
+            "deleted by us: docs/old.md",
+            "new file:   README.md",
+        ]));
+        let statuses: Vec<&MatchSpan> = matches
+            .iter()
+            .filter(|span| span.pattern == "git-status")
+            .collect();
+
+        assert_eq!(
+            statuses
+                .iter()
+                .map(|span| span.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["src/main.rs", "docs/old.md", "README.md"]
+        );
+        assert_eq!(statuses[0].start, "modified:   ".len());
+    }
+
+    #[test]
+    fn finds_git_status_branch_name_with_named_capture() {
+        let matches = find_matches(&lines(["Your branch is up to date with 'origin/main'."]));
+        let branch = matches
+            .iter()
+            .find(|span| span.pattern == "git-status-branch")
+            .unwrap();
+
+        assert_eq!(branch.text, "origin/main");
+    }
+
+    #[test]
+    fn finds_diff_paths_with_named_capture() {
+        let matches = find_matches(&lines(["--- a/src/lib.rs", "+++ b/src/lib.rs"]));
+        let diff_paths: Vec<&str> = matches
+            .iter()
+            .filter(|span| span.pattern == "diff")
+            .map(|span| span.text.as_str())
+            .collect();
+
+        assert_eq!(diff_paths, vec!["src/lib.rs", "src/lib.rs"]);
+    }
+
+    #[test]
+    fn expanded_patterns_win_over_lower_priority_path_and_number_overlaps() {
+        let matches = find_matches(&lines(["+++ b/src/lib.rs", "pod/nginx 0x1234"]));
+        let patterns: Vec<&str> = matches.iter().map(|span| span.pattern.as_str()).collect();
+
+        assert_eq!(patterns, vec!["diff", "kubernetes", "hex"]);
+    }
+
+    #[test]
+    fn expanded_patterns_avoid_common_false_positive_boundaries() {
+        let matches = find_matches(&lines(["not0xabc serviceable api-abcde-aeiou"]));
+        let expanded: Vec<&MatchSpan> = matches
+            .iter()
+            .filter(|span| {
+                matches!(
+                    span.pattern.as_str(),
+                    "hex" | "kubernetes" | "kubernetes-pod"
+                )
+            })
+            .collect();
+
+        assert!(expanded.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add always-enabled expanded tmux-fingers-compatible built-in patterns for hex, Kubernetes, Git status/branch, and diff output
- cover expanded pattern named captures, overlap priority, and false-positive boundaries with unit tests
- document the expanded pattern set and mark remaining v1 Ishes/milestone completed

## Verification
- cargo fmt --all -- --check
- cargo test --all-features
- cargo clippy --all-targets --all
- ish check