### PR TITLE
feat: add custom pattern configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +177,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -190,6 +202,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "toml",
  "unicode-width",
  "which",
 ]
@@ -201,6 +214,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -418,6 +441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +522,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -636,6 +709,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winsafe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
+toml = "0.8"
 unicode-width = "0.2.2"
 which = "6.0"
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Invoke the plugin while a pane is focused, type the displayed hint for the token
 - Herdr 0.7.0 or newer
 - Rust/Cargo to build from source
 - A system clipboard command:
-  - macOS: `pbcopy`
-  - Linux Wayland: `wl-copy`
-  - Linux X11: `xclip` or `xsel`
+    - macOS: `pbcopy`
+    - Linux Wayland: `wl-copy`
+    - Linux X11: `xclip` or `xsel`
 
 ## Install
 
@@ -81,29 +81,36 @@ Herdr Pluck recognizes these built-in token types, in priority order:
 9. IPv4 addresses
 10. Long numeric identifiers
 
-The expanded pattern set is always enabled for v1.1-style compatibility with `tmux-fingers`; user-configurable regex sets remain out of scope for v1.
+Custom global patterns can be added in the plugin config directory:
+
+```bash
+CONFIG_DIR="$(herdr plugin config-dir rmarganti.herdr-pluck)"
+$EDITOR "$CONFIG_DIR/patterns.toml"
+```
+
+Example:
+
+```toml
+[[patterns]]
+name = "jira"
+regex = "\\b[A-Z][A-Z0-9]+-[0-9]+\\b"
+priority = 25
+```
+
+`regex` uses Rust regular expression syntax. If a named capture called `match` is present, only that capture is copied; otherwise the whole regex match is copied:
+
+```toml
+[[patterns]]
+name = "trace-id"
+regex = "trace_id=(?<match>[A-Za-z0-9_-]+)"
+priority = 25
+```
+
+For `trace_id=abc123`, this pattern highlights and copies only `abc123`.
+
+Lower `priority` values win overlapping matches. If omitted, custom pattern priority defaults to `25`.
 
 When identical text appears more than once, every visible occurrence shows the same hint and copies the same text.
-
-## Behavior and limits
-
-- Hints are keyboard-only and fixed-width: one character for small match sets, two characters for larger match sets.
-- Hint characters replace the beginning of matched text on screen so pane geometry stays aligned.
-- Matching is based on visible pane content and handles soft-wrapped tokens such as long URLs.
-- The picker renders a simplified view instead of preserving the source pane's original colors.
-- v1 supports up to 676 unique copied texts in one picker view.
-- Enter is ignored while the picker is active.
-- Invalid full-width hints clear the typed hint buffer so you can try again.
-
-## Not in v1
-
-- Mouse selection
-- OSC52 clipboard copying
-- Custom regex configuration
-- Non-copy actions such as opening URLs or jumping to text
-- Multi-select
-- Preserving original ANSI colors/styles
-- Windows support
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Custom global patterns can be added in the plugin config directory:
 
 ```bash
 CONFIG_DIR="$(herdr plugin config-dir rmarganti.herdr-pluck)"
-$EDITOR "$CONFIG_DIR/patterns.toml"
+$EDITOR "$CONFIG_DIR/config.toml"
 ```
 
 Example:
@@ -96,6 +96,16 @@ name = "jira"
 regex = "\\b[A-Z][A-Z0-9]+-[0-9]+\\b"
 priority = 25
 ```
+
+Project-local patterns are also enabled by default. Herdr Pluck looks for `.herdr-pluck.toml` from the focused pane's working directory up to the Git root. Disable or customize this in the global config:
+
+```toml
+[project]
+patterns = true
+pattern_files = [".herdr-pluck.toml"]
+```
+
+Project-local config files use the same `[[patterns]]` shape as global config. Pattern precedence for equal-priority overlaps is project-local, then global, then built-ins.
 
 `regex` uses Rust regular expression syntax. If a named capture called `match` is present, only that capture is copied; otherwise the whole regex match is copied:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::herdr::commands::{HerdrCommands, ProcessCommandRunner};
-use crate::herdr::context::HerdrContext;
+use crate::model::PatternSpec;
 use crate::patterns::CustomPatternDefinition;
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -8,16 +8,37 @@ use std::path::{Path, PathBuf};
 /// Herdr plugin id used for config directory discovery outside plugin action env.
 pub const PLUGIN_ID: &str = "rmarganti.herdr-pluck";
 
-const PATTERNS_FILE: &str = "patterns.toml";
+const CONFIG_FILE: &str = "config.toml";
+const DEFAULT_PROJECT_CONFIG_FILE: &str = ".herdr-pluck.toml";
 
-/// User-editable global pattern configuration file.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-struct PatternConfigFile {
+/// User-editable global Herdr Pluck configuration file.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+struct GlobalConfigFile {
+    #[serde(default)]
+    project: ProjectConfig,
     #[serde(default)]
     patterns: Vec<PatternConfigEntry>,
 }
 
-/// One custom regex pattern loaded from user configuration.
+/// Project-local pattern discovery settings from global config.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct ProjectConfig {
+    #[serde(default = "default_project_patterns_enabled")]
+    patterns: bool,
+    #[serde(default = "default_project_pattern_files")]
+    pattern_files: Vec<String>,
+}
+
+impl Default for ProjectConfig {
+    fn default() -> Self {
+        Self {
+            patterns: default_project_patterns_enabled(),
+            pattern_files: default_project_pattern_files(),
+        }
+    }
+}
+
+/// One custom regex pattern loaded from user or project configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 struct PatternConfigEntry {
     name: String,
@@ -30,9 +51,17 @@ fn default_custom_priority() -> u16 {
     25
 }
 
-/// Loads global custom patterns, printing non-fatal config errors to stderr.
-pub fn load_global_custom_patterns() -> Vec<CustomPatternDefinition> {
-    match try_load_global_custom_patterns() {
+fn default_project_patterns_enabled() -> bool {
+    true
+}
+
+fn default_project_pattern_files() -> Vec<String> {
+    vec![DEFAULT_PROJECT_CONFIG_FILE.to_string()]
+}
+
+/// Resolves picker pattern specs before launching the temporary picker pane.
+pub fn resolve_pattern_specs(focused_pane_cwd: Option<&Path>) -> Vec<PatternSpec> {
+    match try_resolve_pattern_specs(focused_pane_cwd) {
         Ok(patterns) => patterns,
         Err(error) => {
             eprintln!("Herdr Pluck: failed to load custom patterns: {error:#}");
@@ -41,11 +70,47 @@ pub fn load_global_custom_patterns() -> Vec<CustomPatternDefinition> {
     }
 }
 
-fn try_load_global_custom_patterns() -> Result<Vec<CustomPatternDefinition>> {
+/// Compiles snapshot-provided custom pattern specs, ignoring invalid entries.
+pub fn compile_pattern_specs(specs: &[PatternSpec]) -> Vec<CustomPatternDefinition> {
+    specs
+        .iter()
+        .filter_map(|spec| {
+            CustomPatternDefinition::compile(spec.name.clone(), spec.priority, &spec.regex)
+                .inspect_err(|error| {
+                    eprintln!(
+                        "Herdr Pluck: ignoring invalid pattern {}: {error}",
+                        spec.name
+                    );
+                })
+                .ok()
+        })
+        .collect()
+}
+
+fn try_resolve_pattern_specs(focused_pane_cwd: Option<&Path>) -> Result<Vec<PatternSpec>> {
+    let global_config = load_global_config()?;
+    let mut specs = Vec::new();
+
+    if global_config.project.patterns {
+        if let Some(cwd) = focused_pane_cwd {
+            specs.extend(load_project_pattern_specs(
+                cwd,
+                &global_config.project.pattern_files,
+            ));
+        }
+    }
+    specs.extend(entries_to_specs(global_config.patterns));
+    Ok(specs)
+}
+
+fn load_global_config() -> Result<GlobalConfigFile> {
     let Some(config_dir) = global_config_dir()? else {
-        return Ok(Vec::new());
+        return Ok(GlobalConfigFile {
+            project: ProjectConfig::default(),
+            patterns: Vec::new(),
+        });
     };
-    load_patterns_file(&config_dir.join(PATTERNS_FILE))
+    load_config_file(&config_dir.join(CONFIG_FILE)).map(|config| config.unwrap_or_default())
 }
 
 fn global_config_dir() -> Result<Option<PathBuf>> {
@@ -56,9 +121,9 @@ fn global_config_dir() -> Result<Option<PathBuf>> {
         return Ok(None);
     }
 
-    let context = HerdrContext::from_env();
+    let herdr_bin = std::env::var("HERDR_BIN_PATH").unwrap_or_else(|_| "herdr".to_string());
     let mut runner = ProcessCommandRunner;
-    let mut commands = HerdrCommands::new(&context.herdr_bin, &mut runner);
+    let mut commands = HerdrCommands::new(&herdr_bin, &mut runner);
     let path = commands.plugin_config_dir(PLUGIN_ID)?;
 
     if path.as_os_str().is_empty() {
@@ -68,26 +133,64 @@ fn global_config_dir() -> Result<Option<PathBuf>> {
     }
 }
 
-fn load_patterns_file(path: &Path) -> Result<Vec<CustomPatternDefinition>> {
+fn load_project_pattern_specs(cwd: &Path, pattern_files: &[String]) -> Vec<PatternSpec> {
+    let Some(git_root) = find_git_root(cwd) else {
+        return Vec::new();
+    };
+
+    for dir in ancestors_until(cwd, &git_root) {
+        for file_name in pattern_files {
+            let path = dir.join(file_name);
+            match load_config_file(&path) {
+                Ok(Some(config)) => return entries_to_specs(config.patterns),
+                Ok(None) => continue,
+                Err(error) => {
+                    eprintln!(
+                        "Herdr Pluck: ignoring project pattern config {}: {error:#}",
+                        path.display()
+                    );
+                    return Vec::new();
+                }
+            }
+        }
+    }
+
+    Vec::new()
+}
+
+fn load_config_file(path: &Path) -> Result<Option<GlobalConfigFile>> {
     let content = match std::fs::read_to_string(path) {
         Ok(content) => content,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
             return Err(error).with_context(|| format!("failed to read {}", path.display()))
         }
     };
-    let config: PatternConfigFile =
-        toml::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))?;
+    toml::from_str(&content)
+        .map(Some)
+        .with_context(|| format!("failed to parse {}", path.display()))
+}
 
-    config
-        .patterns
+fn entries_to_specs(entries: Vec<PatternConfigEntry>) -> Vec<PatternSpec> {
+    entries
         .into_iter()
-        .map(|entry| {
-            let name = entry.name;
-            CustomPatternDefinition::compile(name.clone(), entry.priority, &entry.regex)
-                .with_context(|| format!("invalid regex for pattern {name}"))
+        .map(|entry| PatternSpec {
+            name: entry.name,
+            regex: entry.regex,
+            priority: entry.priority,
         })
         .collect()
+}
+
+fn find_git_root(cwd: &Path) -> Option<PathBuf> {
+    cwd.ancestors()
+        .find(|ancestor| ancestor.join(".git").exists())
+        .map(Path::to_path_buf)
+}
+
+fn ancestors_until<'a>(cwd: &'a Path, root: &'a Path) -> impl Iterator<Item = &'a Path> {
+    cwd.ancestors()
+        .take_while(move |ancestor| ancestor.starts_with(root))
 }
 
 #[cfg(test)]
@@ -95,9 +198,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn patterns_file_uses_default_priority_and_named_capture() {
-        let dir = tempfile_dir();
-        let path = dir.join(PATTERNS_FILE);
+    fn config_file_uses_default_priority_and_project_settings() {
+        let dir = tempfile_dir("config-default-priority");
+        let path = dir.join(CONFIG_FILE);
         std::fs::write(
             &path,
             r#"[[patterns]]
@@ -107,16 +210,50 @@ regex = "ABC-(?<match>[0-9]+)"
         )
         .unwrap();
 
-        let patterns = load_patterns_file(&path).unwrap();
+        let config = load_config_file(&path).unwrap().unwrap();
+        let specs = entries_to_specs(config.patterns);
 
-        assert_eq!(patterns.len(), 1);
-        assert_eq!(patterns[0].name(), "ticket");
-        assert_eq!(patterns[0].priority(), 25);
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].name, "ticket");
+        assert_eq!(specs[0].priority, 25);
+        assert!(config.project.patterns);
+        assert_eq!(config.project.pattern_files, vec![".herdr-pluck.toml"]);
     }
 
-    fn tempfile_dir() -> PathBuf {
-        let path =
-            std::env::temp_dir().join(format!("herdr-pluck-config-test-{}", std::process::id()));
+    #[test]
+    fn project_config_is_discovered_up_to_git_root() {
+        let root = tempfile_dir("project-discovery");
+        std::fs::create_dir(root.join(".git")).unwrap();
+        let nested = root.join("a/b");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            root.join(DEFAULT_PROJECT_CONFIG_FILE),
+            r#"[[patterns]]
+name = "project"
+regex = "PROJECT-[0-9]+"
+"#,
+        )
+        .unwrap();
+
+        let specs = load_project_pattern_specs(&nested, &[DEFAULT_PROJECT_CONFIG_FILE.to_string()]);
+
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].name, "project");
+    }
+
+    #[test]
+    fn invalid_project_config_is_ignored() {
+        let root = tempfile_dir("invalid-project");
+        std::fs::create_dir(root.join(".git")).unwrap();
+        std::fs::write(root.join(DEFAULT_PROJECT_CONFIG_FILE), "not toml =").unwrap();
+
+        let specs = load_project_pattern_specs(&root, &[DEFAULT_PROJECT_CONFIG_FILE.to_string()]);
+
+        assert!(specs.is_empty());
+    }
+
+    fn tempfile_dir(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!("herdr-pluck-{name}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&path);
         std::fs::create_dir_all(&path).unwrap();
         path

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,124 @@
+use crate::herdr::commands::{HerdrCommands, ProcessCommandRunner};
+use crate::herdr::context::HerdrContext;
+use crate::patterns::CustomPatternDefinition;
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+/// Herdr plugin id used for config directory discovery outside plugin action env.
+pub const PLUGIN_ID: &str = "rmarganti.herdr-pluck";
+
+const PATTERNS_FILE: &str = "patterns.toml";
+
+/// User-editable global pattern configuration file.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct PatternConfigFile {
+    #[serde(default)]
+    patterns: Vec<PatternConfigEntry>,
+}
+
+/// One custom regex pattern loaded from user configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct PatternConfigEntry {
+    name: String,
+    regex: String,
+    #[serde(default = "default_custom_priority")]
+    priority: u16,
+}
+
+fn default_custom_priority() -> u16 {
+    25
+}
+
+/// Loads global custom patterns, printing non-fatal config errors to stderr.
+pub fn load_global_custom_patterns() -> Vec<CustomPatternDefinition> {
+    match try_load_global_custom_patterns() {
+        Ok(patterns) => patterns,
+        Err(error) => {
+            eprintln!("Herdr Pluck: failed to load custom patterns: {error:#}");
+            Vec::new()
+        }
+    }
+}
+
+fn try_load_global_custom_patterns() -> Result<Vec<CustomPatternDefinition>> {
+    let Some(config_dir) = global_config_dir()? else {
+        return Ok(Vec::new());
+    };
+    load_patterns_file(&config_dir.join(PATTERNS_FILE))
+}
+
+fn global_config_dir() -> Result<Option<PathBuf>> {
+    if let Some(path) = std::env::var_os("HERDR_PLUGIN_CONFIG_DIR") {
+        return Ok(Some(PathBuf::from(path)));
+    }
+    if cfg!(test) {
+        return Ok(None);
+    }
+
+    let context = HerdrContext::from_env();
+    let mut runner = ProcessCommandRunner;
+    let mut commands = HerdrCommands::new(&context.herdr_bin, &mut runner);
+    let path = commands.plugin_config_dir(PLUGIN_ID)?;
+
+    if path.as_os_str().is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(path))
+    }
+}
+
+fn load_patterns_file(path: &Path) -> Result<Vec<CustomPatternDefinition>> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", path.display()))
+        }
+    };
+    let config: PatternConfigFile =
+        toml::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))?;
+
+    config
+        .patterns
+        .into_iter()
+        .map(|entry| {
+            let name = entry.name;
+            CustomPatternDefinition::compile(name.clone(), entry.priority, &entry.regex)
+                .with_context(|| format!("invalid regex for pattern {name}"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn patterns_file_uses_default_priority_and_named_capture() {
+        let dir = tempfile_dir();
+        let path = dir.join(PATTERNS_FILE);
+        std::fs::write(
+            &path,
+            r#"[[patterns]]
+name = "ticket"
+regex = "ABC-(?<match>[0-9]+)"
+"#,
+        )
+        .unwrap();
+
+        let patterns = load_patterns_file(&path).unwrap();
+
+        assert_eq!(patterns.len(), 1);
+        assert_eq!(patterns[0].name(), "ticket");
+        assert_eq!(patterns[0].priority(), 25);
+    }
+
+    fn tempfile_dir() -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("herdr-pluck-config-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+}

--- a/src/herdr/commands.rs
+++ b/src/herdr/commands.rs
@@ -1,6 +1,7 @@
 use crate::model::{PaneId, SplitDirection};
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
+use std::path::PathBuf;
 use std::process::Command;
 
 /// Output captured from a Herdr CLI command.
@@ -135,6 +136,13 @@ impl<'a, R: CommandRunner> HerdrCommands<'a, R> {
         Ok(())
     }
 
+    /// Returns Herdr's stable user-editable config directory for an installed plugin.
+    pub fn plugin_config_dir(&mut self, plugin_id: &str) -> Result<PathBuf> {
+        let stdout = self.run_checked(vec!["plugin", "config-dir", plugin_id])?;
+        let path = String::from_utf8(stdout).context("plugin config-dir output was not UTF-8")?;
+        Ok(PathBuf::from(path.trim()))
+    }
+
     fn run_checked(&mut self, args: Vec<&str>) -> Result<Vec<u8>> {
         self.run_checked_owned(args.into_iter().map(str::to_string).collect())
     }
@@ -240,5 +248,20 @@ pub mod tests {
 
         assert_eq!(response.tab.tab_id, "w:t2");
         assert_eq!(response.root_pane.pane_id, "w:p2");
+    }
+
+    #[test]
+    fn plugin_config_dir_returns_trimmed_path() {
+        let mut runner = FakeRunner::default();
+        runner.push_stdout("/tmp/plugin-config\n");
+        let mut commands = HerdrCommands::new("herdr", &mut runner);
+
+        let path = commands.plugin_config_dir("example.plugin").unwrap();
+
+        assert_eq!(path, PathBuf::from("/tmp/plugin-config"));
+        assert_eq!(
+            runner.calls[0],
+            vec!["plugin", "config-dir", "example.plugin"]
+        );
     }
 }

--- a/src/herdr/context.rs
+++ b/src/herdr/context.rs
@@ -5,6 +5,13 @@ use std::env;
 pub const HERDR_PLUCK_TARGET_PANE_ID: &str = "HERDR_PLUCK_TARGET_PANE_ID";
 pub const HERDR_PLUCK_SNAPSHOT_JSON: &str = "HERDR_PLUCK_SNAPSHOT_JSON";
 
+const HERDR_BIN_PATH: &str = "HERDR_BIN_PATH";
+
+/// Returns the Herdr binary path injected by Herdr, falling back to PATH lookup.
+pub fn herdr_bin_from_env() -> String {
+    env::var(HERDR_BIN_PATH).unwrap_or_else(|_| "herdr".to_string())
+}
+
 /// Runtime Herdr/plugin context used to discover binaries and the source pane.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HerdrContext {
@@ -17,7 +24,7 @@ pub struct HerdrContext {
 impl HerdrContext {
     pub fn from_env() -> Self {
         Self {
-            herdr_bin: env::var("HERDR_BIN_PATH").unwrap_or_else(|_| "herdr".to_string()),
+            herdr_bin: herdr_bin_from_env(),
             plugin_id: env::var("HERDR_PLUGIN_ID").ok(),
             context_json: env::var("HERDR_PLUGIN_CONTEXT_JSON").ok(),
             pane_id: env::var("HERDR_PANE_ID")

--- a/src/herdr/context.rs
+++ b/src/herdr/context.rs
@@ -1,6 +1,7 @@
 use crate::model::PaneId;
 use serde_json::Value;
 use std::env;
+use std::path::PathBuf;
 
 pub const HERDR_PLUCK_TARGET_PANE_ID: &str = "HERDR_PLUCK_TARGET_PANE_ID";
 pub const HERDR_PLUCK_SNAPSHOT_JSON: &str = "HERDR_PLUCK_SNAPSHOT_JSON";
@@ -38,8 +39,7 @@ impl HerdrContext {
             return Some(PaneId::new(pane_id.clone()));
         }
 
-        let context = self.context_json.as_ref()?;
-        let value: Value = serde_json::from_str(context).ok()?;
+        let value = self.context_value()?;
         find_string_at_paths(
             &value,
             &[
@@ -52,6 +52,26 @@ impl HerdrContext {
             ],
         )
         .map(PaneId::new)
+    }
+
+    /// Working directory associated with the focused source pane, if Herdr provided one.
+    pub fn focused_pane_cwd(&self) -> Option<PathBuf> {
+        let value = self.context_value()?;
+        find_string_at_paths(
+            &value,
+            &[
+                &["focused_pane", "cwd"],
+                &["pane", "cwd"],
+                &["focused_pane_cwd"],
+                &["workspace_cwd"],
+            ],
+        )
+        .map(PathBuf::from)
+    }
+
+    fn context_value(&self) -> Option<Value> {
+        let context = self.context_json.as_ref()?;
+        serde_json::from_str(context).ok()
     }
 }
 
@@ -102,5 +122,20 @@ mod tests {
         };
 
         assert_eq!(context.target_pane(), Some(PaneId::new("from-env")));
+    }
+
+    #[test]
+    fn extracts_focused_pane_cwd_from_context_json() {
+        let context = HerdrContext {
+            herdr_bin: "herdr".to_string(),
+            plugin_id: None,
+            context_json: Some(r#"{"focused_pane_cwd":"/repo/subdir"}"#.to_string()),
+            pane_id: None,
+        };
+
+        assert_eq!(
+            context.focused_pane_cwd(),
+            Some(PathBuf::from("/repo/subdir"))
+        );
     }
 }

--- a/src/herdr/executor.rs
+++ b/src/herdr/executor.rs
@@ -6,7 +6,7 @@ use crate::herdr::snapshot::{
     build_source_snapshot, choose_picker_snapshot_transport, inert_pane_command, picker_command,
     remove_snapshot_file, write_snapshot_file, SnapshotFile, SnapshotTransport,
 };
-use crate::model::{LayoutNode, PaneId, PickerSnapshot, TempTabSession};
+use crate::model::{LayoutNode, PaneId, PatternSpec, PickerSnapshot, TempTabSession};
 use crate::viewport::map_visible_viewport;
 use anyhow::{anyhow, Context, Result};
 use std::collections::HashMap;
@@ -27,6 +27,7 @@ pub fn launch_layout_tab_picker<R: CommandRunner>(
     runner: &mut R,
     target: &PaneId,
     binary_path: &Path,
+    custom_patterns: Vec<PatternSpec>,
 ) -> Result<LayoutTabLaunch> {
     let layout_bytes = {
         let mut commands = HerdrCommands::new(herdr_bin, runner);
@@ -97,6 +98,7 @@ pub fn launch_layout_tab_picker<R: CommandRunner>(
         logical_lines,
         Some(visible_viewport),
         session.clone(),
+        custom_patterns,
     )?;
     let snapshot_file = match choose_picker_snapshot_transport(&snapshot)? {
         SnapshotTransport::TempFile => write_snapshot_file(&snapshot)?,
@@ -378,6 +380,11 @@ mod tests {
             &mut runner,
             &PaneId::new("p2"),
             Path::new("/bin/herdr-pluck"),
+            vec![PatternSpec {
+                name: "custom".to_string(),
+                regex: "CUSTOM-[0-9]+".to_string(),
+                priority: 25,
+            }],
         )
         .unwrap();
 
@@ -393,6 +400,9 @@ mod tests {
                 "tp2".to_string(),
                 expected_picker_command.clone(),
             ]));
+        let snapshot = crate::herdr::snapshot::read_snapshot_file(&launch.snapshot_file.path)
+            .expect("snapshot should be readable");
+        assert_eq!(snapshot.custom_patterns[0].name, "custom");
         let _ = std::fs::remove_file(launch.snapshot_file.path);
     }
 
@@ -406,6 +416,7 @@ mod tests {
             &mut runner,
             &PaneId::new("p1"),
             Path::new("/bin/herdr-pluck"),
+            Vec::new(),
         )
         .unwrap_err();
 
@@ -432,6 +443,7 @@ mod tests {
             &mut runner,
             &PaneId::new("p2"),
             Path::new("/bin/herdr-pluck"),
+            Vec::new(),
         )
         .unwrap();
 
@@ -478,6 +490,7 @@ mod tests {
             &mut runner,
             &PaneId::new("p2"),
             Path::new("/bin/herdr-pluck"),
+            Vec::new(),
         )
         .unwrap_err();
 

--- a/src/herdr/mod.rs
+++ b/src/herdr/mod.rs
@@ -4,6 +4,7 @@ pub mod executor;
 pub mod layout;
 pub mod snapshot;
 
+use crate::config::resolve_pattern_specs;
 use crate::herdr::commands::ProcessCommandRunner;
 use crate::herdr::context::HerdrContext;
 use crate::herdr::executor::{cleanup_session, launch_layout_tab_picker, run_snapshot_picker};
@@ -41,7 +42,15 @@ impl HerdrAdapter {
     pub fn open_layout_tab_picker(&self, target: &PaneId) -> Result<()> {
         let binary_path = std::env::current_exe().context("failed to locate herdr-pluck binary")?;
         let mut runner = ProcessCommandRunner;
-        launch_layout_tab_picker(&self.context.herdr_bin, &mut runner, target, &binary_path)?;
+        let focused_pane_cwd = self.context.focused_pane_cwd();
+        let custom_patterns = resolve_pattern_specs(focused_pane_cwd.as_deref());
+        launch_layout_tab_picker(
+            &self.context.herdr_bin,
+            &mut runner,
+            target,
+            &binary_path,
+            custom_patterns,
+        )?;
         Ok(())
     }
 

--- a/src/herdr/snapshot.rs
+++ b/src/herdr/snapshot.rs
@@ -1,6 +1,6 @@
 use crate::herdr::layout::{derive_source_geometry, derive_source_pane_geometries, LayoutSnapshot};
 use crate::model::{
-    PaneId, PaneTextCaptureMode, PickerSnapshot, SourcePaneSnapshot, TempTabSession,
+    PaneId, PaneTextCaptureMode, PatternSpec, PickerSnapshot, SourcePaneSnapshot, TempTabSession,
     VisibleViewport,
 };
 use anyhow::{Context, Result};
@@ -68,6 +68,7 @@ pub fn build_source_snapshot(
     logical_lines: Vec<String>,
     visible_viewport: Option<VisibleViewport>,
     session: TempTabSession,
+    custom_patterns: Vec<PatternSpec>,
 ) -> Result<PickerSnapshot> {
     let source_tab_id = layout
         .tab_id
@@ -100,6 +101,7 @@ pub fn build_source_snapshot(
             capture_mode: PaneTextCaptureMode::ExactVisibleUnwrapped,
         },
         session,
+        custom_patterns,
     })
 }
 
@@ -216,6 +218,7 @@ mod tests {
                 return_tab_id: "t1".to_string(),
                 return_pane_id: PaneId::new("p1"),
             },
+            custom_patterns: Vec::new(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod clipboard;
+pub mod config;
 pub mod herdr;
 pub mod hints;
 pub mod model;

--- a/src/model.rs
+++ b/src/model.rs
@@ -152,11 +152,21 @@ pub struct TempTabSession {
     pub return_pane_id: PaneId,
 }
 
+/// Serializable regex pattern config resolved before the picker pane starts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PatternSpec {
+    pub name: String,
+    pub regex: String,
+    pub priority: u16,
+}
+
 /// Full picker launch payload passed from the action process to picker mode.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PickerSnapshot {
     pub source: SourcePaneSnapshot,
     pub session: TempTabSession,
+    #[serde(default)]
+    pub custom_patterns: Vec<PatternSpec>,
 }
 
 /// Direction of a Herdr binary pane split as exposed by layout snapshots and replay commands.

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -8,7 +8,7 @@ const KUBERNETES_RESOURCE_KINDS: &str = "deployment.app|binding|componentstatuse
 
 #[derive(Debug)]
 struct PatternDefinition {
-    name: &'static str,
+    name: String,
     /// Match precedence where lower numbers beat higher numbers.
     /// ie. `1` is the number one priority, while `5` is a lower priority
     priority: u16,
@@ -16,12 +16,46 @@ struct PatternDefinition {
 }
 
 impl PatternDefinition {
-    fn compile(name: &'static str, priority: u16, pattern: &str) -> Self {
-        Self {
-            name,
+    fn compile(name: impl Into<String>, priority: u16, pattern: &str) -> Self {
+        Self::try_compile(name, priority, pattern)
+            .expect("built-in Herdr Pluck pattern must compile")
+    }
+
+    fn try_compile(
+        name: impl Into<String>,
+        priority: u16,
+        pattern: &str,
+    ) -> Result<Self, regex::Error> {
+        Ok(Self {
+            name: name.into(),
             priority,
-            regex: Regex::new(pattern).expect("built-in Herdr Pluck pattern must compile"),
-        }
+            regex: Regex::new(pattern)?,
+        })
+    }
+}
+
+/// User-defined regex pattern loaded from Herdr Pluck config.
+#[derive(Debug)]
+pub struct CustomPatternDefinition(PatternDefinition);
+
+impl CustomPatternDefinition {
+    /// Compiles a user pattern, preserving regex diagnostics for config errors.
+    pub fn compile(
+        name: impl Into<String>,
+        priority: u16,
+        pattern: &str,
+    ) -> Result<Self, regex::Error> {
+        PatternDefinition::try_compile(name, priority, pattern).map(Self)
+    }
+
+    /// User-visible pattern name.
+    pub fn name(&self) -> &str {
+        &self.0.name
+    }
+
+    /// Match precedence where lower numbers are higher priority.
+    pub fn priority(&self) -> u16 {
+        self.0.priority
     }
 }
 
@@ -32,12 +66,15 @@ struct MatchCandidate {
     pattern_order: usize,
 }
 
-/// Finds accepted built-in pattern matches in first-visible order.
-///
-/// Matching runs on unwrapped logical lines. Returned spans are all accepted visible occurrences;
-/// duplicate copied texts are intentionally preserved for the hint engine to deduplicate later.
-pub fn find_matches(lines: &[String]) -> Vec<MatchSpan> {
-    find_matches_with_patterns(lines, built_in_patterns())
+/// Finds matches using built-ins followed by user-defined custom patterns.
+pub fn find_matches(
+    lines: &[String],
+    custom_patterns: &[CustomPatternDefinition],
+) -> Vec<MatchSpan> {
+    let mut patterns = Vec::with_capacity(built_in_patterns().len() + custom_patterns.len());
+    patterns.extend(built_in_patterns().iter());
+    patterns.extend(custom_patterns.iter().map(|pattern| &pattern.0));
+    find_matches_with_patterns(lines, &patterns)
 }
 
 fn built_in_patterns() -> &'static [PatternDefinition] {
@@ -79,7 +116,7 @@ fn built_in_patterns() -> &'static [PatternDefinition] {
     })
 }
 
-fn find_matches_with_patterns(lines: &[String], patterns: &[PatternDefinition]) -> Vec<MatchSpan> {
+fn find_matches_with_patterns(lines: &[String], patterns: &[&PatternDefinition]) -> Vec<MatchSpan> {
     let candidates = collect_candidates(lines, patterns);
     let mut accepted = resolve_overlaps(candidates);
     accepted.sort_by(|left, right| {
@@ -92,7 +129,7 @@ fn find_matches_with_patterns(lines: &[String], patterns: &[PatternDefinition]) 
 }
 
 /// Collects all candidate matches for all patterns with their pattern definition order for tie-breaking.
-fn collect_candidates(lines: &[String], patterns: &[PatternDefinition]) -> Vec<MatchCandidate> {
+fn collect_candidates(lines: &[String], patterns: &[&PatternDefinition]) -> Vec<MatchCandidate> {
     let mut candidates = Vec::new();
 
     for (line_idx, line) in lines.iter().enumerate() {
@@ -108,7 +145,7 @@ fn collect_candidates(lines: &[String], patterns: &[PatternDefinition]) -> Vec<M
                         start: regex_match.start(),
                         end: regex_match.end(),
                         text: regex_match.as_str().to_string(),
-                        pattern: pattern.name.to_string(),
+                        pattern: pattern.name.clone(),
                         priority: pattern.priority,
                     },
                     pattern_order,
@@ -150,6 +187,11 @@ fn resolve_overlaps(mut candidates: Vec<MatchCandidate>) -> Vec<MatchSpan> {
 mod tests {
     use super::*;
 
+    fn find_matches_with_defaults_only(lines: &[String]) -> Vec<MatchSpan> {
+        let patterns = built_in_patterns().iter().collect::<Vec<_>>();
+        find_matches_with_patterns(lines, &patterns)
+    }
+
     fn lines<const N: usize>(values: [&str; N]) -> Vec<String> {
         values.into_iter().map(String::from).collect()
     }
@@ -158,9 +200,13 @@ mod tests {
         PatternDefinition::compile(name, priority, pattern)
     }
 
+    fn test_patterns(patterns: &[PatternDefinition]) -> Vec<&PatternDefinition> {
+        patterns.iter().collect()
+    }
+
     #[test]
     fn finds_url_schemes() {
-        let matches = find_matches(&lines([
+        let matches = find_matches_with_defaults_only(&lines([
             "https://example.com http://example.com git@github.com:org/repo.git",
             "git://host/repo ssh://host/path ftp://host/path file:///tmp/file",
         ]));
@@ -186,7 +232,7 @@ mod tests {
 
     #[test]
     fn url_stops_at_delimiters() {
-        let matches = find_matches(&lines([
+        let matches = find_matches_with_defaults_only(&lines([
             "(https://a.test/path) 'https://b.test' \"https://c.test\"",
         ]));
         let urls: Vec<&str> = matches
@@ -203,7 +249,8 @@ mod tests {
 
     #[test]
     fn url_preserves_non_delimiter_trailing_punctuation() {
-        let matches = find_matches(&lines(["see https://example.com/path., next"]));
+        let matches =
+            find_matches_with_defaults_only(&lines(["see https://example.com/path., next"]));
         let url = matches.iter().find(|span| span.pattern == "url").unwrap();
 
         assert_eq!(url.text, "https://example.com/path.,");
@@ -211,7 +258,8 @@ mod tests {
 
     #[test]
     fn finds_style_paths() {
-        let matches = find_matches(&lines(["/tmp/foo/bar src/main.rs foo/bar dir/sub/"]));
+        let matches =
+            find_matches_with_defaults_only(&lines(["/tmp/foo/bar src/main.rs foo/bar dir/sub/"]));
         let paths: Vec<&str> = matches
             .iter()
             .filter(|span| span.pattern == "path")
@@ -226,7 +274,7 @@ mod tests {
 
     #[test]
     fn finds_uppercase_and_lowercase_uuids() {
-        let matches = find_matches(&lines([
+        let matches = find_matches_with_defaults_only(&lines([
             "ids 123e4567-e89b-12d3-a456-426614174000 123E4567-E89B-12D3-A456-426614174000",
         ]));
         let uuids: Vec<&str> = matches
@@ -246,7 +294,7 @@ mod tests {
 
     #[test]
     fn finds_git_sha_lengths_with_uppercase_support() {
-        let matches = find_matches(&lines([
+        let matches = find_matches_with_defaults_only(&lines([
             "sha abcDEF1 abcdef1234567890abcdef1234567890abcdef12 abcdef1234567890abcdef1234567890abcdef123",
         ]));
         let shas: Vec<&str> = matches
@@ -263,7 +311,8 @@ mod tests {
 
     #[test]
     fn finds_loose_ipv4() {
-        let matches = find_matches(&lines(["hosts 192.168.1.10 999.999.999.999"]));
+        let matches =
+            find_matches_with_defaults_only(&lines(["hosts 192.168.1.10 999.999.999.999"]));
         let ips: Vec<&str> = matches
             .iter()
             .filter(|span| span.pattern == "ipv4")
@@ -275,7 +324,7 @@ mod tests {
 
     #[test]
     fn finds_long_numbers_inside_text() {
-        let matches = find_matches(&lines(["zzz1234zzz issue-5678 foo_9012"]));
+        let matches = find_matches_with_defaults_only(&lines(["zzz1234zzz issue-5678 foo_9012"]));
         let numbers: Vec<&str> = matches
             .iter()
             .filter(|span| span.pattern == "number")
@@ -287,7 +336,8 @@ mod tests {
 
     #[test]
     fn finds_hex_literals_before_numeric_submatches() {
-        let matches = find_matches(&lines(["values 0xdeadBEEF 0x1234 not0xabc"]));
+        let matches =
+            find_matches_with_defaults_only(&lines(["values 0xdeadBEEF 0x1234 not0xabc"]));
         let hexes: Vec<&str> = matches
             .iter()
             .filter(|span| span.pattern == "hex")
@@ -302,7 +352,7 @@ mod tests {
 
     #[test]
     fn finds_kubernetes_resource_references() {
-        let matches = find_matches(&lines([
+        let matches = find_matches_with_defaults_only(&lines([
             "kubectl get pod/nginx-123 service/api deployment.apps/frontend",
         ]));
         let resources: Vec<&str> = matches
@@ -319,7 +369,7 @@ mod tests {
 
     #[test]
     fn finds_deployment_managed_kubernetes_pod_names() {
-        let matches = find_matches(&lines([
+        let matches = find_matches_with_defaults_only(&lines([
             "pods nginx-deployment-66b6c48dd5-7xb2r api-abcde-12345 bad-pod-abcde-aeiou",
         ]));
         let pods: Vec<&str> = matches
@@ -333,7 +383,7 @@ mod tests {
 
     #[test]
     fn finds_git_status_paths_with_named_capture() {
-        let matches = find_matches(&lines([
+        let matches = find_matches_with_defaults_only(&lines([
             "modified:   src/main.rs",
             "deleted by us: docs/old.md",
             "new file:   README.md",
@@ -355,7 +405,9 @@ mod tests {
 
     #[test]
     fn finds_git_status_branch_name_with_named_capture() {
-        let matches = find_matches(&lines(["Your branch is up to date with 'origin/main'."]));
+        let matches = find_matches_with_defaults_only(&lines([
+            "Your branch is up to date with 'origin/main'.",
+        ]));
         let branch = matches
             .iter()
             .find(|span| span.pattern == "git-status-branch")
@@ -366,7 +418,8 @@ mod tests {
 
     #[test]
     fn finds_diff_paths_with_named_capture() {
-        let matches = find_matches(&lines(["--- a/src/lib.rs", "+++ b/src/lib.rs"]));
+        let matches =
+            find_matches_with_defaults_only(&lines(["--- a/src/lib.rs", "+++ b/src/lib.rs"]));
         let diff_paths: Vec<&str> = matches
             .iter()
             .filter(|span| span.pattern == "diff")
@@ -378,7 +431,8 @@ mod tests {
 
     #[test]
     fn expanded_patterns_win_over_lower_priority_path_and_number_overlaps() {
-        let matches = find_matches(&lines(["+++ b/src/lib.rs", "pod/nginx 0x1234"]));
+        let matches =
+            find_matches_with_defaults_only(&lines(["+++ b/src/lib.rs", "pod/nginx 0x1234"]));
         let patterns: Vec<&str> = matches.iter().map(|span| span.pattern.as_str()).collect();
 
         assert_eq!(patterns, vec!["diff", "kubernetes", "hex"]);
@@ -386,7 +440,8 @@ mod tests {
 
     #[test]
     fn expanded_patterns_avoid_common_false_positive_boundaries() {
-        let matches = find_matches(&lines(["not0xabc serviceable api-abcde-aeiou"]));
+        let matches =
+            find_matches_with_defaults_only(&lines(["not0xabc serviceable api-abcde-aeiou"]));
         let expanded: Vec<&MatchSpan> = matches
             .iter()
             .filter(|span| {
@@ -403,7 +458,8 @@ mod tests {
     #[test]
     fn named_match_capture_defines_text_and_range() {
         let patterns = vec![test_pattern("status", 10, r#"status=\[(?<match>[^\]]+)\]"#)];
-        let matches = find_matches_with_patterns(&lines(["status=[copy-me]"]), &patterns);
+        let matches =
+            find_matches_with_patterns(&lines(["status=[copy-me]"]), &test_patterns(&patterns));
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].text, "copy-me");
@@ -414,7 +470,8 @@ mod tests {
     #[test]
     fn full_match_is_used_without_named_capture() {
         let patterns = vec![test_pattern("word", 10, r#"copy-me"#)];
-        let matches = find_matches_with_patterns(&lines(["xx copy-me yy"]), &patterns);
+        let matches =
+            find_matches_with_patterns(&lines(["xx copy-me yy"]), &test_patterns(&patterns));
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].text, "copy-me");
@@ -428,7 +485,8 @@ mod tests {
             test_pattern("wrapped", 10, r#"prefix-(?<match>abc)-suffix"#),
             test_pattern("prefix", 20, r#"prefix"#),
         ];
-        let matches = find_matches_with_patterns(&lines(["prefix-abc-suffix"]), &patterns);
+        let matches =
+            find_matches_with_patterns(&lines(["prefix-abc-suffix"]), &test_patterns(&patterns));
         let texts: Vec<&str> = matches.iter().map(|span| span.text.as_str()).collect();
 
         assert_eq!(texts, vec!["prefix", "abc"]);
@@ -436,7 +494,8 @@ mod tests {
 
     #[test]
     fn url_wins_over_path_inside_url() {
-        let matches = find_matches(&lines(["open https://example.com/src/main.rs"]));
+        let matches =
+            find_matches_with_defaults_only(&lines(["open https://example.com/src/main.rs"]));
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].pattern, "url");
@@ -445,7 +504,8 @@ mod tests {
 
     #[test]
     fn uuid_wins_over_sha_and_number_submatches() {
-        let matches = find_matches(&lines(["id 123e4567-e89b-12d3-a456-426614174000"]));
+        let matches =
+            find_matches_with_defaults_only(&lines(["id 123e4567-e89b-12d3-a456-426614174000"]));
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].pattern, "uuid");
@@ -453,7 +513,7 @@ mod tests {
 
     #[test]
     fn git_sha_wins_over_number_submatch() {
-        let matches = find_matches(&lines(["sha abc1234"]));
+        let matches = find_matches_with_defaults_only(&lines(["sha abc1234"]));
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].pattern, "git-sha");
@@ -466,7 +526,7 @@ mod tests {
             test_pattern("short-high", 10, r#"abc"#),
             test_pattern("long-low", 20, r#"abcdef"#),
         ];
-        let matches = find_matches_with_patterns(&lines(["abcdef"]), &patterns);
+        let matches = find_matches_with_patterns(&lines(["abcdef"]), &test_patterns(&patterns));
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].pattern, "short-high");
@@ -478,7 +538,7 @@ mod tests {
             test_pattern("short", 10, r#"abc"#),
             test_pattern("long", 10, r#"abcdef"#),
         ];
-        let matches = find_matches_with_patterns(&lines(["abcdef"]), &patterns);
+        let matches = find_matches_with_patterns(&lines(["abcdef"]), &test_patterns(&patterns));
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].pattern, "long");
@@ -487,7 +547,7 @@ mod tests {
     #[test]
     fn earlier_position_wins_within_same_priority_and_length() {
         let patterns = vec![test_pattern("word", 10, r#"abc"#)];
-        let matches = find_matches_with_patterns(&lines(["abc abc"]), &patterns);
+        let matches = find_matches_with_patterns(&lines(["abc abc"]), &test_patterns(&patterns));
 
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].start, 0);
@@ -500,7 +560,7 @@ mod tests {
             test_pattern("first", 10, r#"abc"#),
             test_pattern("second", 10, r#"abc"#),
         ];
-        let matches = find_matches_with_patterns(&lines(["abc"]), &patterns);
+        let matches = find_matches_with_patterns(&lines(["abc"]), &test_patterns(&patterns));
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].pattern, "first");
@@ -508,7 +568,7 @@ mod tests {
 
     #[test]
     fn output_order_is_visible_order_not_acceptance_priority() {
-        let matches = find_matches(&lines(["1234", "https://example.com"]));
+        let matches = find_matches_with_defaults_only(&lines(["1234", "https://example.com"]));
         let texts: Vec<&str> = matches.iter().map(|span| span.text.as_str()).collect();
 
         assert_eq!(texts, vec!["1234", "https://example.com"]);
@@ -516,7 +576,7 @@ mod tests {
 
     #[test]
     fn duplicate_copied_text_occurrences_are_preserved() {
-        let matches = find_matches(&lines(["/tmp/foo /tmp/foo"]));
+        let matches = find_matches_with_defaults_only(&lines(["/tmp/foo /tmp/foo"]));
         let paths: Vec<&MatchSpan> = matches
             .iter()
             .filter(|span| span.pattern == "path")
@@ -530,10 +590,35 @@ mod tests {
     #[test]
     fn overlap_is_line_local() {
         let patterns = vec![test_pattern("same", 10, r#"abc"#)];
-        let matches = find_matches_with_patterns(&lines(["abc", "abc"]), &patterns);
+        let matches = find_matches_with_patterns(&lines(["abc", "abc"]), &test_patterns(&patterns));
 
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].line, 0);
         assert_eq!(matches[1].line, 1);
+    }
+
+    #[test]
+    fn custom_patterns_are_appended_after_builtins() {
+        let custom = vec![CustomPatternDefinition::compile("ticket", 25, r#"ABC-[0-9]+"#).unwrap()];
+        let matches = find_matches(&lines(["fix ABC-1234"]), &custom);
+
+        assert!(matches
+            .iter()
+            .any(|span| span.pattern == "ticket" && span.text == "ABC-1234"));
+    }
+
+    #[test]
+    fn custom_pattern_priority_participates_in_overlap_resolution() {
+        let custom = vec![CustomPatternDefinition::compile(
+            "command",
+            12,
+            r#"git branch -D [A-Za-z0-9._/-]+"#,
+        )
+        .unwrap()];
+        let matches = find_matches(&lines(["run git branch -D feature/foo"]), &custom);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].pattern, "command");
+        assert_eq!(matches[0].text, "git branch -D feature/foo");
     }
 }

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -66,14 +66,14 @@ struct MatchCandidate {
     pattern_order: usize,
 }
 
-/// Finds matches using built-ins followed by user-defined custom patterns.
+/// Finds matches using user-defined custom patterns followed by built-ins.
 pub fn find_matches(
     lines: &[String],
     custom_patterns: &[CustomPatternDefinition],
 ) -> Vec<MatchSpan> {
-    let mut patterns = Vec::with_capacity(built_in_patterns().len() + custom_patterns.len());
-    patterns.extend(built_in_patterns().iter());
+    let mut patterns = Vec::with_capacity(custom_patterns.len() + built_in_patterns().len());
     patterns.extend(custom_patterns.iter().map(|pattern| &pattern.0));
+    patterns.extend(built_in_patterns().iter());
     find_matches_with_patterns(lines, &patterns)
 }
 
@@ -598,7 +598,7 @@ mod tests {
     }
 
     #[test]
-    fn custom_patterns_are_appended_after_builtins() {
+    fn custom_patterns_are_searched_before_builtins() {
         let custom = vec![CustomPatternDefinition::compile("ticket", 25, r#"ABC-[0-9]+"#).unwrap()];
         let matches = find_matches(&lines(["fix ABC-1234"]), &custom);
 

--- a/src/picker/render.rs
+++ b/src/picker/render.rs
@@ -1,3 +1,4 @@
+use crate::config::load_global_custom_patterns;
 use crate::hints::{assign_hints, HintAssignments};
 use crate::model::{PickerOutcome, PickerSnapshot, RenderLine, RenderSpan, RenderStyle};
 use crate::patterns::find_matches;
@@ -35,8 +36,10 @@ pub fn build_picker_view(snapshot: &PickerSnapshot) -> PickerView {
         .as_ref()
         .map(|viewport| viewport.logical_lines.as_slice())
         .unwrap_or(&snapshot.source.logical_lines);
-    let matches = find_matches(logical_lines);
+    let custom_patterns = load_global_custom_patterns();
+    let matches = find_matches(logical_lines, &custom_patterns);
     let assignments = assign_hints(matches.clone());
+
     let lines = if assignments.is_empty() {
         no_matches_view(
             snapshot.source.target_content_width,

--- a/src/picker/render.rs
+++ b/src/picker/render.rs
@@ -1,4 +1,4 @@
-use crate::config::load_global_custom_patterns;
+use crate::config::compile_pattern_specs;
 use crate::hints::{assign_hints, HintAssignments};
 use crate::model::{PickerOutcome, PickerSnapshot, RenderLine, RenderSpan, RenderStyle};
 use crate::patterns::find_matches;
@@ -36,7 +36,7 @@ pub fn build_picker_view(snapshot: &PickerSnapshot) -> PickerView {
         .as_ref()
         .map(|viewport| viewport.logical_lines.as_slice())
         .unwrap_or(&snapshot.source.logical_lines);
-    let custom_patterns = load_global_custom_patterns();
+    let custom_patterns = compile_pattern_specs(&snapshot.custom_patterns);
     let matches = find_matches(logical_lines, &custom_patterns);
     let assignments = assign_hints(matches.clone());
 
@@ -174,6 +174,7 @@ mod tests {
                 return_tab_id: "t1".to_string(),
                 return_pane_id: PaneId::new("p1"),
             },
+            custom_patterns: Vec::new(),
         }
     }
 

--- a/src/picker/session.rs
+++ b/src/picker/session.rs
@@ -150,6 +150,7 @@ mod tests {
                 return_tab_id: "t1".to_string(),
                 return_pane_id: PaneId::new("p1"),
             },
+            custom_patterns: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
- add global Herdr Pluck config loading from the plugin config dir with user-defined regex patterns
- add project-local pattern discovery via .herdr-pluck.toml from the focused pane cwd up to the Git root
- snapshot resolved custom pattern specs for picker execution and document global/project config usage

## Verification
- cargo fmt --all -- --check
- cargo test --all-features
- cargo clippy --all-targets --all