### PR TITLE
ci: gh actions, bin build and install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Test
+        run: cargo test --all-features
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Test
+        run: cargo test --all-features
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all -- -D warnings
+
+  build:
+    needs: checks
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: aarch64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Restore cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Zig
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        uses: mlugg/setup-zig@v2
+
+      - name: Install cargo-zigbuild
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: cargo install cargo-zigbuild --locked
+
+      - name: Build binary
+        run: |
+          if [ "${{ matrix.target }}" = "x86_64-unknown-linux-musl" ]; then
+            cargo zigbuild --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      - name: Package archive
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          ARCHIVE="herdr-pluck-v${VERSION}-${TARGET}.tar.gz"
+          mkdir -p dist
+          cp "target/${TARGET}/release/herdr-pluck" dist/
+          tar -czf "$ARCHIVE" -C dist herdr-pluck
+          shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            herdr-pluck-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
+            herdr-pluck-${{ github.ref_name }}-${{ matrix.target }}.tar.gz.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/bin

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Invoke the plugin while a pane is focused, type the displayed hint for the token
 ## Requirements
 
 - Herdr 0.7.0 or newer
-- Rust/Cargo to build from source
+- For release installs, a download tool:
+    - `curl` or `wget`
+- Rust/Cargo only when developing locally or installing an unreleased ref without a matching prebuilt binary
 - A system clipboard command:
     - macOS: `pbcopy`
     - Linux Wayland: `wl-copy`
@@ -23,16 +25,22 @@ From the remote repository:
 herdr plugin install rmarganti/herdr-pluck
 ```
 
+Published releases provide prebuilt binaries for these targets:
+
+- macOS Apple Silicon: `aarch64-apple-darwin`
+- Linux x86_64: `x86_64-unknown-linux-musl`
+
 To install a specific branch, tag, or commit, pass `--ref`:
 
 ```bash
 herdr plugin install rmarganti/herdr-pluck --ref main
 ```
 
+When the checked out plugin source matches a published release tag, install downloads the matching GitHub Release asset. Unreleased branches and commits fall back to a local Cargo build when Rust is available.
+
 From this checkout:
 
 ```bash
-cargo build --release
 herdr plugin link .
 ```
 
@@ -136,14 +144,20 @@ Lower `priority` values win overlapping matches. If omitted, custom pattern prio
 
 When identical text appears more than once, every visible occurrence shows the same hint and copies the same text.
 
+## Releasing binaries
+
+Tag releases as `vX.Y.Z`. GitHub Actions validates the crate, builds release archives, and uploads platform binaries to the matching GitHub Release.
+
 ## Troubleshooting
 
-If invoking the action does nothing useful, check that the plugin is linked and the release binary exists:
+If invoking the action does nothing useful, check that the plugin is linked and the installed binary exists:
 
 ```bash
-cargo build --release
 herdr plugin link .
+ls -l ./bin/herdr-pluck
 herdr plugin action list --plugin rmarganti.herdr-pluck
 ```
+
+If you are installing an unreleased ref, make sure either a matching release asset exists for the plugin version or Rust/Cargo is available for the local fallback build.
 
 If copying fails, install one of the supported clipboard tools for your platform and try again.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,10 +6,10 @@ description = "Inline keyboard hints for copying visible terminal tokens from He
 platforms = ["linux", "macos"]
 
 [[build]]
-command = ["cargo", "build", "--release"]
+command = ["./scripts/install-binary.sh"]
 
 [[actions]]
 id = "pluck"
 title = "Pluck visible token"
 contexts = ["pane", "workspace"]
-command = ["./target/release/herdr-pluck", "open"]
+command = ["./bin/herdr-pluck", "open"]

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO_OWNER="rmarganti"
+REPO_NAME="herdr-pluck"
+BIN_DIR="bin"
+BIN_PATH="$BIN_DIR/herdr-pluck"
+log() {
+    printf '%s\n' "$*" >&2
+}
+
+plugin_version() {
+    awk -F'"' '/^version = "/ { print $2; exit }' herdr-plugin.toml
+}
+
+archive_name() {
+    version="$1"
+    target="$2"
+    printf '%s-v%s-%s.tar.gz' "$REPO_NAME" "$version" "$target"
+}
+
+release_url() {
+    version="$1"
+    archive="$2"
+    printf 'https://github.com/%s/%s/releases/download/v%s/%s' "$REPO_OWNER" "$REPO_NAME" "$version" "$archive"
+}
+
+current_target() {
+    os=$(uname -s)
+    arch=$(uname -m)
+
+    case "$os" in
+        Darwin)
+            case "$arch" in
+                arm64|aarch64) printf 'aarch64-apple-darwin' ;;
+                *) log "Unsupported macOS architecture: $arch"; exit 1 ;;
+            esac
+            ;;
+        Linux)
+            case "$arch" in
+                x86_64|amd64) printf 'x86_64-unknown-linux-musl' ;;
+                *) log "Unsupported Linux architecture: $arch"; exit 1 ;;
+            esac
+            ;;
+        *)
+            log "Unsupported operating system: $os"
+            exit 1
+            ;;
+    esac
+}
+
+have_command() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+is_exact_release_checkout() {
+    version="$1"
+
+    if ! have_command git || [ ! -d .git ]; then
+        return 0
+    fi
+
+    tag=$(git describe --tags --exact-match 2>/dev/null || true)
+    [ "$tag" = "v$version" ]
+}
+
+download_release_binary() {
+    version="$1"
+    target="$2"
+    archive=$(archive_name "$version" "$target")
+    url=$(release_url "$version" "$archive")
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT INT TERM HUP
+
+    log "Downloading $url"
+
+    if have_command curl; then
+        curl -fsSL "$url" -o "$tmpdir/$archive" || return 1
+    elif have_command wget; then
+        wget -qO "$tmpdir/$archive" "$url" || return 1
+    else
+        log "Need curl or wget to install release binary"
+        return 1
+    fi
+
+    mkdir -p "$BIN_DIR"
+    tar -xzf "$tmpdir/$archive" -C "$tmpdir"
+    cp "$tmpdir/herdr-pluck" "$BIN_PATH"
+    chmod +x "$BIN_PATH"
+
+    rm -rf "$tmpdir"
+    trap - EXIT INT TERM HUP
+}
+
+build_from_source() {
+    log "Falling back to local cargo build"
+    cargo build --release
+    mkdir -p "$BIN_DIR"
+    cp target/release/herdr-pluck "$BIN_PATH"
+    chmod +x "$BIN_PATH"
+}
+
+main() {
+    version=$(plugin_version)
+    target=$(current_target)
+
+    if is_exact_release_checkout "$version"; then
+        if download_release_binary "$version" "$target"; then
+            log "Installed $BIN_PATH for $target"
+            exit 0
+        fi
+    fi
+
+    if have_command cargo; then
+        build_from_source
+        log "Installed $BIN_PATH from local source"
+        exit 0
+    fi
+
+    log "No prebuilt binary found for version $version on $target, and cargo is unavailable"
+    exit 1
+}
+
+main "$@"


### PR DESCRIPTION
- Adds github actions for CI checks and binary artifacts
- Updates herdr plugin install config to pull binary from GH artifacts
