### PR TITLE
Detach clipboard commands from picker panes

### DIFF
--- a/src/clipboard/system.rs
+++ b/src/clipboard/system.rs
@@ -13,14 +13,15 @@ impl ClipboardCommandRunner for SystemCommandRunner {
     }
 
     fn run_with_stdin(&self, tool: ClipboardTool, stdin: &str) -> Result<(), ClipboardError> {
-        let mut child = Command::new(tool.name)
-            .args(tool.args)
-            .stdin(Stdio::piped())
-            .spawn()
-            .map_err(|err| ClipboardError::SpawnFailed {
-                tool: tool.name.to_string(),
-                message: err.to_string(),
-            })?;
+        let mut command = clipboard_command(tool);
+        let mut child =
+            command
+                .stdin(Stdio::piped())
+                .spawn()
+                .map_err(|err| ClipboardError::SpawnFailed {
+                    tool: tool.name.to_string(),
+                    message: err.to_string(),
+                })?;
 
         if let Some(mut child_stdin) = child.stdin.take() {
             use std::io::Write;
@@ -45,5 +46,42 @@ impl ClipboardCommandRunner for SystemCommandRunner {
                 status: status.to_string(),
             })
         }
+    }
+}
+
+#[cfg(unix)]
+fn clipboard_command(tool: ClipboardTool) -> Command {
+    let mut command = Command::new("setsid");
+    command.arg(tool.name).args(tool.args);
+    command
+}
+
+#[cfg(not(unix))]
+fn clipboard_command(tool: ClipboardTool) -> Command {
+    let mut command = Command::new(tool.name);
+    command.args(tool.args);
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn clipboard_command_is_wrapped_with_setsid_on_unix() {
+        let command = clipboard_command(ClipboardTool {
+            name: "wl-copy",
+            args: &["--trim-newline"],
+        });
+
+        assert_eq!(command.get_program(), "setsid");
+        assert_eq!(
+            command
+                .get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["wl-copy", "--trim-newline"]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- wrap Unix clipboard commands with `setsid` before launching them from picker panes
- keep the existing stdin/write/wait behavior and non-Unix direct command path
- add a regression test covering the Unix clipboard command wrapper

## Why

When the picker runs inside a temporary Herdr pane/PTY, clipboard helpers such as `wl-copy` can exit successfully without leaving usable clipboard contents after the pane/session exits. Launching the helper in a new session detaches it from the picker pane lifecycle while still allowing Herdr Pluck to report spawn/write/exit failures.