### PR TITLE
fix: prefer prebuilt plugin binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Invoke the plugin while a pane is focused, type the displayed hint for the token
 - Herdr 0.7.0 or newer
 - For release installs, a download tool:
     - `curl` or `wget`
-- Rust/Cargo only when developing locally or installing an unreleased ref without a matching prebuilt binary
+- Rust/Cargo only when forcing a source build or when no matching prebuilt binary is available
 - A system clipboard command:
     - macOS: `pbcopy`
     - Linux Wayland: `wl-copy`
@@ -36,12 +36,18 @@ To install a specific branch, tag, or commit, pass `--ref`:
 herdr plugin install rmarganti/herdr-pluck --ref main
 ```
 
-When the checked out plugin source matches a published release tag, install downloads the matching GitHub Release asset. Unreleased branches and commits fall back to a local Cargo build when Rust is available.
+Install first downloads the GitHub Release asset matching the version in `herdr-plugin.toml`. If that asset is unavailable, it falls back to a local Cargo build when Rust is available.
 
 From this checkout:
 
 ```bash
 herdr plugin link .
+```
+
+By default, linking also installs the prebuilt binary matching `herdr-plugin.toml`. To build the checked-out source instead:
+
+```bash
+HERDR_PLUCK_BUILD_FROM_SOURCE=1 herdr plugin link .
 ```
 
 Verify Herdr can see the action:
@@ -158,6 +164,6 @@ ls -l ./bin/herdr-pluck
 herdr plugin action list --plugin rmarganti.herdr-pluck
 ```
 
-If you are installing an unreleased ref, make sure either a matching release asset exists for the plugin version or Rust/Cargo is available for the local fallback build.
+If no release asset matches the plugin version, make sure Rust/Cargo is available for the local fallback build. Set `HERDR_PLUCK_BUILD_FROM_SOURCE=1` to skip the release download and build the checked-out source explicitly.
 
 If copying fails, install one of the supported clipboard tools for your platform and try again.

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -53,17 +53,6 @@ have_command() {
     command -v "$1" >/dev/null 2>&1
 }
 
-is_exact_release_checkout() {
-    version="$1"
-
-    if ! have_command git || [ ! -d .git ]; then
-        return 0
-    fi
-
-    tag=$(git describe --tags --exact-match 2>/dev/null || true)
-    [ "$tag" = "v$version" ]
-}
-
 download_release_binary() {
     version="$1"
     target="$2"
@@ -93,7 +82,7 @@ download_release_binary() {
 }
 
 build_from_source() {
-    log "Falling back to local cargo build"
+    log "Building from local source with cargo"
     cargo build --release
     mkdir -p "$BIN_DIR"
     cp target/release/herdr-pluck "$BIN_PATH"
@@ -104,14 +93,24 @@ main() {
     version=$(plugin_version)
     target=$(current_target)
 
-    if is_exact_release_checkout "$version"; then
-        if download_release_binary "$version" "$target"; then
-            log "Installed $BIN_PATH for $target"
-            exit 0
+    if [ "${HERDR_PLUCK_BUILD_FROM_SOURCE:-0}" = "1" ]; then
+        if ! have_command cargo; then
+            log "HERDR_PLUCK_BUILD_FROM_SOURCE=1 requires cargo"
+            exit 1
         fi
+
+        build_from_source
+        log "Installed $BIN_PATH from local source"
+        exit 0
+    fi
+
+    if download_release_binary "$version" "$target"; then
+        log "Installed $BIN_PATH for $target"
+        exit 0
     fi
 
     if have_command cargo; then
+        log "No prebuilt binary found for version $version on $target"
         build_from_source
         log "Installed $BIN_PATH from local source"
         exit 0


### PR DESCRIPTION
- Downloads the release asset matching herdr-plugin.toml without relying on local Git tags
- Falls back to Cargo when the binary is unavailable and adds an explicit source-build override for linked development
- Documents download-first and source-build behavior
- Verified against the real v0.1.0 Apple Silicon release asset; formatting and Clippy pass