### PR TITLE
feat: render picker in an in-place overlay pane instead of a temporary tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ herdr server reload-config
 
 1. Focus a Herdr pane containing a URL, path, commit SHA, UUID, IP address, long numeric identifier, hex literal, Kubernetes reference, Git status path, branch, or diff path.
 2. Invoke `rmarganti.herdr-pluck.pluck` through your keybinding or Herdr's plugin action command.
-3. Herdr Pluck opens a temporary picker tab that mirrors the source layout and shows hints over copyable text in the target pane.
+3. Herdr Pluck opens an overlay pane in place that shows hints over copyable text in the target pane.
 4. Type the shown one- or two-letter hint to copy that token and close the picker.
 5. Press Escape or Ctrl-C to cancel without copying.
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,3 +13,9 @@ id = "pluck"
 title = "Pluck visible token"
 contexts = ["pane", "workspace"]
 command = ["./bin/herdr-pluck", "open"]
+
+[[panes]]
+id = "picker"
+title = "Herdr Pluck"
+placement = "overlay"
+command = ["./bin/herdr-pluck", "pick"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::herdr::HerdrAdapter;
+use crate::herdr::{HerdrAdapter, HERDR_PLUCK_SNAPSHOT_PATH};
 use crate::model::PaneId;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -17,18 +17,19 @@ pub struct Cli {
 
 #[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
 pub enum Command {
-    /// Action entrypoint: recreate the current layout in a temporary picker tab.
+    /// Action entrypoint: capture the focused pane and open the picker overlay.
     Open {
         /// Override the pane to pluck from. Defaults to Herdr invocation context.
         #[arg(long)]
         target_pane: Option<String>,
     },
 
-    /// Picker entrypoint: run inside the temporary layout-tab target pane.
+    /// Picker entrypoint: run inside the Herdr overlay pane.
     Pick {
         /// Temp JSON snapshot path produced by `open`.
+        /// Defaults to the HERDR_PLUCK_SNAPSHOT_PATH environment variable.
         #[arg(long)]
-        snapshot: PathBuf,
+        snapshot: Option<PathBuf>,
     },
 }
 
@@ -46,9 +47,12 @@ pub fn run_with(cli: Cli) -> Result<()> {
                 .or_else(|| adapter.target_pane_from_context())
                 .context("could not determine target pane from --target-pane, HERDR_PANE_ID, HERDR_ACTIVE_PANE_ID, or Herdr context")?;
 
-            adapter.open_layout_tab_picker(&target)?;
+            adapter.open_overlay_picker(&target)?;
         }
         Command::Pick { snapshot } => {
+            let snapshot = snapshot
+                .or_else(|| std::env::var(HERDR_PLUCK_SNAPSHOT_PATH).ok().map(PathBuf::from))
+                .context("picker snapshot path missing: pass --snapshot or set HERDR_PLUCK_SNAPSHOT_PATH")?;
             adapter.run_picker_from_snapshot(&snapshot)?;
         }
     }

--- a/src/herdr/commands.rs
+++ b/src/herdr/commands.rs
@@ -1,6 +1,5 @@
-use crate::model::{PaneId, SplitDirection};
+use crate::model::PaneId;
 use anyhow::{anyhow, Context, Result};
-use serde::Deserialize;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -76,63 +75,31 @@ impl<'a, R: CommandRunner> HerdrCommands<'a, R> {
         Ok(String::from_utf8_lossy(&stdout).into_owned())
     }
 
-    pub fn tab_create(
+    /// Opens a manifest-declared plugin overlay pane over the currently active pane.
+    pub fn plugin_pane_open_overlay(
         &mut self,
-        workspace_id: &str,
-        label: &str,
+        plugin_id: &str,
+        entrypoint: &str,
+        env: &[(&str, String)],
         focus: bool,
-    ) -> Result<TabCreateResponse> {
+    ) -> Result<()> {
         let mut args = vec![
-            "tab".to_string(),
-            "create".to_string(),
-            "--workspace".to_string(),
-            workspace_id.to_string(),
-            "--label".to_string(),
-            label.to_string(),
-        ];
-        args.push(if focus { "--focus" } else { "--no-focus" }.to_string());
-        let stdout = self.run_checked_owned(args)?;
-        parse_json(&stdout, "tab create")
-    }
-
-    pub fn pane_split(
-        &mut self,
-        pane: &PaneId,
-        direction: SplitDirection,
-        ratio: f32,
-        focus: bool,
-    ) -> Result<PaneSplitResponse> {
-        let mut args = vec![
+            "plugin".to_string(),
             "pane".to_string(),
-            "split".to_string(),
-            pane.0.clone(),
-            "--direction".to_string(),
-            direction.as_cli_arg().to_string(),
-            "--ratio".to_string(),
-            ratio.to_string(),
+            "open".to_string(),
+            "--plugin".to_string(),
+            plugin_id.to_string(),
+            "--entrypoint".to_string(),
+            entrypoint.to_string(),
+            "--placement".to_string(),
+            "overlay".to_string(),
         ];
+        for (key, value) in env {
+            args.push("--env".to_string());
+            args.push(format!("{key}={value}"));
+        }
         args.push(if focus { "--focus" } else { "--no-focus" }.to_string());
-        let stdout = self.run_checked_owned(args)?;
-        parse_json(&stdout, "pane split")
-    }
-
-    pub fn pane_run(&mut self, pane: &PaneId, command: &str) -> Result<()> {
-        self.run_checked(vec!["pane", "run", &pane.0, command])?;
-        Ok(())
-    }
-
-    pub fn pane_zoom_on(&mut self, pane: &PaneId) -> Result<()> {
-        self.run_checked(vec!["pane", "zoom", &pane.0, "--on"])?;
-        Ok(())
-    }
-
-    pub fn tab_focus(&mut self, tab_id: &str) -> Result<()> {
-        self.run_checked(vec!["tab", "focus", tab_id])?;
-        Ok(())
-    }
-
-    pub fn tab_close(&mut self, tab_id: &str) -> Result<()> {
-        self.run_checked(vec!["tab", "close", tab_id])?;
+        self.run_checked_owned(args)?;
         Ok(())
     }
 
@@ -159,45 +126,6 @@ impl<'a, R: CommandRunner> HerdrCommands<'a, R> {
             ))
         }
     }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct Envelope<T> {
-    result: T,
-}
-
-/// Parsed `tab create` response fields used by layout-tab launching.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-pub struct TabCreateResponse {
-    pub tab: TabInfo,
-    pub root_pane: PaneInfo,
-}
-
-/// Parsed `pane split` response fields used by split replay.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-pub struct PaneSplitResponse {
-    pub pane: PaneInfo,
-}
-
-/// Minimal tab metadata returned by Herdr CLI commands.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-pub struct TabInfo {
-    pub tab_id: String,
-    pub workspace_id: String,
-}
-
-/// Minimal pane metadata returned by Herdr CLI commands.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-pub struct PaneInfo {
-    pub pane_id: String,
-    pub tab_id: String,
-    pub workspace_id: String,
-}
-
-fn parse_json<T: for<'de> Deserialize<'de>>(bytes: &[u8], context: &str) -> Result<T> {
-    let envelope: Envelope<T> = serde_json::from_slice(bytes)
-        .with_context(|| format!("failed to parse Herdr {context} JSON"))?;
-    Ok(envelope.result)
 }
 
 #[cfg(test)]
@@ -239,15 +167,37 @@ pub mod tests {
     }
 
     #[test]
-    fn parses_tab_create_response() {
+    fn plugin_pane_open_overlay_passes_env_and_focus() {
         let mut runner = FakeRunner::default();
-        runner.push_stdout(r#"{"result":{"tab":{"tab_id":"w:t2","workspace_id":"w"},"root_pane":{"pane_id":"w:p2","tab_id":"w:t2","workspace_id":"w"}}}"#);
+        runner.push_stdout(r#"{"result":{"type":"plugin_pane_opened"}}"#);
         let mut commands = HerdrCommands::new("herdr", &mut runner);
 
-        let response = commands.tab_create("w", "label", false).unwrap();
+        commands
+            .plugin_pane_open_overlay(
+                "rmarganti.herdr-pluck",
+                "picker",
+                &[("HERDR_PLUCK_SNAPSHOT_PATH", "/tmp/s.json".to_string())],
+                true,
+            )
+            .unwrap();
 
-        assert_eq!(response.tab.tab_id, "w:t2");
-        assert_eq!(response.root_pane.pane_id, "w:p2");
+        assert_eq!(
+            runner.calls[0],
+            vec![
+                "plugin",
+                "pane",
+                "open",
+                "--plugin",
+                "rmarganti.herdr-pluck",
+                "--entrypoint",
+                "picker",
+                "--placement",
+                "overlay",
+                "--env",
+                "HERDR_PLUCK_SNAPSHOT_PATH=/tmp/s.json",
+                "--focus",
+            ]
+        );
     }
 
     #[test]

--- a/src/herdr/context.rs
+++ b/src/herdr/context.rs
@@ -3,8 +3,8 @@ use serde_json::Value;
 use std::env;
 use std::path::PathBuf;
 
-pub const HERDR_PLUCK_TARGET_PANE_ID: &str = "HERDR_PLUCK_TARGET_PANE_ID";
-pub const HERDR_PLUCK_SNAPSHOT_JSON: &str = "HERDR_PLUCK_SNAPSHOT_JSON";
+/// Env var carrying the snapshot file path into the overlay picker pane.
+pub const HERDR_PLUCK_SNAPSHOT_PATH: &str = "HERDR_PLUCK_SNAPSHOT_PATH";
 
 const HERDR_BIN_PATH: &str = "HERDR_BIN_PATH";
 

--- a/src/herdr/executor.rs
+++ b/src/herdr/executor.rs
@@ -1,293 +1,83 @@
 use crate::herdr::commands::{CommandRunner, HerdrCommands};
-use crate::herdr::layout::{
-    derive_layout_recreation_plan, derive_source_geometry, parse_layout_snapshot,
-};
+use crate::herdr::context::HERDR_PLUCK_SNAPSHOT_PATH;
+use crate::herdr::layout::{derive_source_geometry, parse_layout_snapshot};
 use crate::herdr::snapshot::{
-    build_source_snapshot, choose_picker_snapshot_transport, inert_pane_command, picker_command,
-    remove_snapshot_file, write_snapshot_file, SnapshotFile, SnapshotTransport,
+    build_source_snapshot, remove_snapshot_file, write_snapshot_file, SnapshotFile,
 };
-use crate::model::{LayoutNode, PaneId, PatternSpec, PickerSnapshot, TempTabSession};
+use crate::model::{PaneId, PatternSpec, PickerSnapshot};
 use crate::viewport::map_visible_viewport;
-use anyhow::{anyhow, Context, Result};
-use std::collections::HashMap;
-use std::path::Path;
+use anyhow::Result;
 
-/// Result of launching a temporary layout-tab picker.
+/// Manifest pane entrypoint id that runs picker mode inside the overlay.
+pub const PICKER_PANE_ENTRYPOINT: &str = "picker";
+
+/// Result of launching the overlay picker pane.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LayoutTabLaunch {
-    pub session: TempTabSession,
-    pub target_temp_pane_id: PaneId,
+pub struct OverlayLaunch {
     pub snapshot_file: SnapshotFile,
-    pub pane_mapping: HashMap<PaneId, PaneId>,
 }
 
-/// Captures the source pane, recreates its tab layout, and launches picker mode in the target pane.
-pub fn launch_layout_tab_picker<R: CommandRunner>(
+/// Captures the focused source pane and opens the picker as a Herdr overlay pane.
+///
+/// Herdr attaches overlay panes to the currently active pane, closes them when
+/// the picker process exits, and restores focus itself — no explicit cleanup.
+pub fn launch_overlay_picker<R: CommandRunner>(
     herdr_bin: &str,
     runner: &mut R,
     target: &PaneId,
-    binary_path: &Path,
+    plugin_id: &str,
     custom_patterns: Vec<PatternSpec>,
-) -> Result<LayoutTabLaunch> {
+) -> Result<OverlayLaunch> {
     let layout_bytes = {
         let mut commands = HerdrCommands::new(herdr_bin, runner);
         commands.pane_layout(target)?
     };
     let layout = parse_layout_snapshot(&layout_bytes)?;
-    let plan = derive_layout_recreation_plan(&layout, target)?;
-
-    let read_lines = derive_source_geometry(&layout, target)
-        .source_content_rect
-        .height;
-    if read_lines == 0 {
+    let geometry = derive_source_geometry(&layout, target);
+    let content_rect = geometry.source_content_rect;
+    if content_rect.height == 0 {
         anyhow::bail!("target pane {target} has zero visible content height");
     }
+
     let visible_text = {
         let mut commands = HerdrCommands::new(herdr_bin, runner);
-        commands.pane_read_visible(target, read_lines)?
+        commands.pane_read_visible(target, content_rect.height)?
     };
     let visible_rows = visible_text.lines().map(str::to_string).collect::<Vec<_>>();
-    let visible_viewport = map_visible_viewport(
-        visible_rows,
-        derive_source_geometry(&layout, target)
-            .source_content_rect
-            .width,
-        read_lines,
-    );
+    let visible_viewport =
+        map_visible_viewport(visible_rows, content_rect.width, content_rect.height);
     let logical_lines = visible_viewport.logical_lines.clone();
-
-    let workspace_id = layout
-        .workspace_id
-        .as_deref()
-        .context("pane layout did not include workspace id")?;
-    let return_tab_id = layout
-        .tab_id
-        .clone()
-        .context("pane layout did not include return tab id")?;
-
-    let tab = {
-        let mut commands = HerdrCommands::new(herdr_bin, runner);
-        commands.tab_create(workspace_id, "Herdr Pluck", true)?
-    };
-    let session = TempTabSession {
-        temp_tab_id: tab.tab.tab_id.clone(),
-        return_tab_id,
-        return_pane_id: target.clone(),
-    };
-
-    let replay_result = replay_layout_tree(
-        herdr_bin,
-        runner,
-        &plan.root,
-        PaneId::new(tab.root_pane.pane_id.clone()),
-        target,
-    )
-    .inspect_err(|_| {
-        let _ = cleanup_session(herdr_bin, runner, &session);
-    })?;
-
-    let target_temp_pane_id = replay_result
-        .pane_mapping
-        .get(target)
-        .cloned()
-        .ok_or_else(|| anyhow!("layout replay did not create a temp pane for target {target}"))?;
 
     let snapshot = build_source_snapshot(
         &layout,
         target,
         logical_lines,
         Some(visible_viewport),
-        session.clone(),
         custom_patterns,
     )?;
-    let snapshot_file = match choose_picker_snapshot_transport(&snapshot)? {
-        SnapshotTransport::TempFile => write_snapshot_file(&snapshot)?,
-        SnapshotTransport::EnvJson => {
-            anyhow::bail!("env-json picker snapshot transport is not supported for pane run")
-        }
-    };
+    let snapshot_file = write_snapshot_file(&snapshot)?;
 
-    if layout.zoomed && layout_target_is_focused(&layout, target) {
+    let open_result = {
         let mut commands = HerdrCommands::new(herdr_bin, runner);
-        if let Err(error) = commands.pane_zoom_on(&target_temp_pane_id) {
-            cleanup_failed_launch(herdr_bin, runner, &session, &snapshot_file);
-            return Err(error);
-        }
-    }
-
-    if let Err(error) = launch_pane_commands(
-        herdr_bin,
-        runner,
-        binary_path,
-        &target_temp_pane_id,
-        &snapshot_file,
-        &replay_result.pane_mapping,
-    ) {
-        cleanup_failed_launch(herdr_bin, runner, &session, &snapshot_file);
+        commands.plugin_pane_open_overlay(
+            plugin_id,
+            PICKER_PANE_ENTRYPOINT,
+            &[(
+                HERDR_PLUCK_SNAPSHOT_PATH,
+                snapshot_file.path.display().to_string(),
+            )],
+            true,
+        )
+    };
+    if let Err(error) = open_result {
+        let _ = remove_snapshot_file(&snapshot_file.path);
         return Err(error);
     }
 
-    Ok(LayoutTabLaunch {
-        session,
-        target_temp_pane_id,
-        snapshot_file,
-        pane_mapping: replay_result.pane_mapping,
-    })
+    Ok(OverlayLaunch { snapshot_file })
 }
 
-fn cleanup_failed_launch<R: CommandRunner>(
-    herdr_bin: &str,
-    runner: &mut R,
-    session: &TempTabSession,
-    snapshot_file: &SnapshotFile,
-) {
-    let _ = cleanup_session(herdr_bin, runner, session);
-    let _ = remove_snapshot_file(&snapshot_file.path);
-}
-
-fn layout_target_is_focused(
-    layout: &crate::herdr::layout::LayoutSnapshot,
-    target: &PaneId,
-) -> bool {
-    layout
-        .focused_pane_id
-        .as_ref()
-        .is_some_and(|focused| focused == &target.0)
-        || layout
-            .panes
-            .iter()
-            .any(|pane| pane.pane_id == target.0 && pane.focused)
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ReplayResult {
-    pane_mapping: HashMap<PaneId, PaneId>,
-}
-
-fn replay_layout_tree<R: CommandRunner>(
-    herdr_bin: &str,
-    runner: &mut R,
-    root: &LayoutNode,
-    root_temp_pane: PaneId,
-    target: &PaneId,
-) -> Result<ReplayResult> {
-    let mut pane_mapping = HashMap::new();
-    replay_node(
-        herdr_bin,
-        runner,
-        root,
-        root_temp_pane,
-        target,
-        &mut pane_mapping,
-    )?;
-    Ok(ReplayResult { pane_mapping })
-}
-
-fn replay_node<R: CommandRunner>(
-    herdr_bin: &str,
-    runner: &mut R,
-    node: &LayoutNode,
-    current_temp_pane: PaneId,
-    target: &PaneId,
-    pane_mapping: &mut HashMap<PaneId, PaneId>,
-) -> Result<()> {
-    match node {
-        LayoutNode::Pane { source_pane_id, .. } => {
-            pane_mapping.insert(source_pane_id.clone(), current_temp_pane);
-            Ok(())
-        }
-        LayoutNode::Split {
-            direction,
-            ratio,
-            first,
-            second,
-            ..
-        } => {
-            let target_in_second = node_contains_source(second, target);
-            let split = {
-                let mut commands = HerdrCommands::new(herdr_bin, runner);
-                commands.pane_split(&current_temp_pane, *direction, *ratio, target_in_second)?
-            };
-            let second_temp_pane = PaneId::new(split.pane.pane_id);
-            replay_node(
-                herdr_bin,
-                runner,
-                first,
-                current_temp_pane,
-                target,
-                pane_mapping,
-            )?;
-            replay_node(
-                herdr_bin,
-                runner,
-                second,
-                second_temp_pane,
-                target,
-                pane_mapping,
-            )
-        }
-    }
-}
-
-fn node_contains_source(node: &LayoutNode, target: &PaneId) -> bool {
-    match node {
-        LayoutNode::Pane { source_pane_id, .. } => source_pane_id == target,
-        LayoutNode::Split { first, second, .. } => {
-            node_contains_source(first, target) || node_contains_source(second, target)
-        }
-    }
-}
-
-fn launch_pane_commands<R: CommandRunner>(
-    herdr_bin: &str,
-    runner: &mut R,
-    binary_path: &Path,
-    target_temp_pane_id: &PaneId,
-    snapshot_file: &SnapshotFile,
-    pane_mapping: &HashMap<PaneId, PaneId>,
-) -> Result<()> {
-    let picker_command = picker_command(binary_path, &snapshot_file.path);
-    for temp_pane in pane_mapping.values() {
-        let command = if temp_pane == target_temp_pane_id {
-            picker_command.as_str()
-        } else {
-            inert_pane_command()
-        };
-        let mut commands = HerdrCommands::new(herdr_bin, runner);
-        commands.pane_run(temp_pane, command)?;
-    }
-    Ok(())
-}
-
-/// Attempts to restore focus and close the temporary tab by explicit session ids.
-pub fn cleanup_session<R: CommandRunner>(
-    herdr_bin: &str,
-    runner: &mut R,
-    session: &TempTabSession,
-) -> Result<()> {
-    let mut first_error = None;
-    {
-        let mut commands = HerdrCommands::new(herdr_bin, runner);
-        if let Err(error) = commands.tab_focus(&session.return_tab_id) {
-            first_error = Some(error);
-        }
-    }
-    {
-        let mut commands = HerdrCommands::new(herdr_bin, runner);
-        if let Err(error) = commands.tab_close(&session.temp_tab_id) {
-            if first_error.is_none() {
-                first_error = Some(error);
-            }
-        }
-    }
-
-    match first_error {
-        Some(error) => Err(error),
-        None => Ok(()),
-    }
-}
-
-/// Runs picker input/copy flow for a loaded layout-tab snapshot.
+/// Runs picker input/copy flow for a loaded overlay snapshot.
 pub fn run_snapshot_picker(snapshot: &PickerSnapshot) -> Result<()> {
     crate::picker::run_picker(snapshot)?;
     Ok(())
@@ -297,14 +87,11 @@ pub fn run_snapshot_picker(snapshot: &PickerSnapshot) -> Result<()> {
 mod tests {
     use super::*;
     use crate::herdr::commands::tests::FakeRunner;
-    use crate::model::{Rect, SplitDirection};
+    use crate::herdr::snapshot::read_snapshot_file;
+    use crate::model::PatternSpec;
 
     fn layout_json() -> &'static str {
         r#"{"result":{"layout":{"area":{"x":0,"y":0,"width":100,"height":40},"focused_pane_id":"p2","panes":[{"focused":false,"pane_id":"p1","rect":{"x":0,"y":0,"width":40,"height":40}},{"focused":true,"pane_id":"p2","rect":{"x":40,"y":0,"width":60,"height":40}}],"splits":[{"direction":"right","ratio":0.4,"rect":{"x":0,"y":0,"width":100,"height":40}}],"tab_id":"t1","workspace_id":"w1","zoomed":false}}}"#
-    }
-
-    fn zoomed_layout_json() -> &'static str {
-        r#"{"result":{"layout":{"area":{"x":0,"y":0,"width":100,"height":40},"focused_pane_id":"p2","panes":[{"focused":false,"pane_id":"p1","rect":{"x":0,"y":0,"width":40,"height":40}},{"focused":true,"pane_id":"p2","rect":{"x":40,"y":0,"width":60,"height":40}}],"splits":[{"direction":"right","ratio":0.4,"rect":{"x":0,"y":0,"width":100,"height":40}}],"tab_id":"t1","workspace_id":"w1","zoomed":true}}}"#
     }
 
     fn zero_height_layout_json() -> &'static str {
@@ -312,74 +99,17 @@ mod tests {
     }
 
     #[test]
-    fn replay_split_tree_maps_source_to_temp_panes() {
-        let root = LayoutNode::Split {
-            direction: SplitDirection::Right,
-            ratio: 0.4,
-            first: Box::new(LayoutNode::Pane {
-                source_pane_id: PaneId::new("p1"),
-                rect: Rect::new(0, 0, 40, 40),
-            }),
-            second: Box::new(LayoutNode::Pane {
-                source_pane_id: PaneId::new("p2"),
-                rect: Rect::new(40, 0, 60, 40),
-            }),
-            rect: Rect::new(0, 0, 100, 40),
-        };
-        let mut runner = FakeRunner::default();
-        runner.push_stdout(
-            r#"{"result":{"pane":{"pane_id":"temp2","tab_id":"tt","workspace_id":"w1"}}}"#,
-        );
-
-        let result = replay_layout_tree(
-            "herdr",
-            &mut runner,
-            &root,
-            PaneId::new("temp1"),
-            &PaneId::new("p2"),
-        )
-        .unwrap();
-
-        assert_eq!(
-            result.pane_mapping.get(&PaneId::new("p1")),
-            Some(&PaneId::new("temp1"))
-        );
-        assert_eq!(
-            result.pane_mapping.get(&PaneId::new("p2")),
-            Some(&PaneId::new("temp2"))
-        );
-        assert_eq!(
-            runner.calls[0],
-            vec![
-                "pane",
-                "split",
-                "temp1",
-                "--direction",
-                "right",
-                "--ratio",
-                "0.4",
-                "--focus"
-            ]
-        );
-    }
-
-    #[test]
-    fn launch_creates_tab_replays_layout_and_runs_picker() {
+    fn launch_reads_pane_and_opens_overlay_with_snapshot_env() {
         let mut runner = FakeRunner::default();
         runner.push_stdout(layout_json());
         runner.push_stdout("https://example.com\n");
-        runner.push_stdout(r#"{"result":{"tab":{"tab_id":"tt","workspace_id":"w1"},"root_pane":{"pane_id":"tp1","tab_id":"tt","workspace_id":"w1"}}}"#);
-        runner.push_stdout(
-            r#"{"result":{"pane":{"pane_id":"tp2","tab_id":"tt","workspace_id":"w1"}}}"#,
-        );
-        runner.push_stdout(r#"{"result":{"type":"ok"}}"#);
-        runner.push_stdout(r#"{"result":{"type":"ok"}}"#);
+        runner.push_stdout(r#"{"result":{"type":"plugin_pane_opened"}}"#);
 
-        let launch = launch_layout_tab_picker(
+        let launch = launch_overlay_picker(
             "herdr",
             &mut runner,
             &PaneId::new("p2"),
-            Path::new("/bin/herdr-pluck"),
+            "rmarganti.herdr-pluck",
             vec![PatternSpec {
                 name: "custom".to_string(),
                 regex: "CUSTOM-[0-9]+".to_string(),
@@ -388,20 +118,30 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(launch.target_temp_pane_id, PaneId::new("tp2"));
-        let expected_picker_command = "'/bin/herdr-pluck' pick --snapshot ".to_string()
-            + &crate::herdr::snapshot::shell_quote(
-                &launch.snapshot_file.path.display().to_string(),
-            );
-        assert!(runner.calls.iter().any(|call| call
-            == &vec![
+        let expected_env = format!(
+            "HERDR_PLUCK_SNAPSHOT_PATH={}",
+            launch.snapshot_file.path.display()
+        );
+        assert_eq!(
+            runner.calls[2],
+            vec![
+                "plugin".to_string(),
                 "pane".to_string(),
-                "run".to_string(),
-                "tp2".to_string(),
-                expected_picker_command.clone(),
-            ]));
-        let snapshot = crate::herdr::snapshot::read_snapshot_file(&launch.snapshot_file.path)
-            .expect("snapshot should be readable");
+                "open".to_string(),
+                "--plugin".to_string(),
+                "rmarganti.herdr-pluck".to_string(),
+                "--entrypoint".to_string(),
+                "picker".to_string(),
+                "--placement".to_string(),
+                "overlay".to_string(),
+                "--env".to_string(),
+                expected_env,
+                "--focus".to_string(),
+            ]
+        );
+
+        let snapshot = read_snapshot_file(&launch.snapshot_file.path).unwrap();
+        assert_eq!(snapshot.source.target_pane_id, PaneId::new("p2"));
         assert_eq!(snapshot.custom_patterns[0].name, "custom");
         let _ = std::fs::remove_file(launch.snapshot_file.path);
     }
@@ -411,11 +151,11 @@ mod tests {
         let mut runner = FakeRunner::default();
         runner.push_stdout(zero_height_layout_json());
 
-        let error = launch_layout_tab_picker(
+        let error = launch_overlay_picker(
             "herdr",
             &mut runner,
             &PaneId::new("p1"),
-            Path::new("/bin/herdr-pluck"),
+            "rmarganti.herdr-pluck",
             Vec::new(),
         )
         .unwrap_err();
@@ -426,102 +166,27 @@ mod tests {
     }
 
     #[test]
-    fn launch_zooms_temp_target_when_source_target_is_zoomed() {
+    fn failed_overlay_open_removes_snapshot_file() {
         let mut runner = FakeRunner::default();
-        runner.push_stdout(zoomed_layout_json());
+        runner.push_stdout(layout_json());
         runner.push_stdout("https://example.com\n");
-        runner.push_stdout(r#"{"result":{"tab":{"tab_id":"tt","workspace_id":"w1"},"root_pane":{"pane_id":"tp1","tab_id":"tt","workspace_id":"w1"}}}"#);
-        runner.push_stdout(
-            r#"{"result":{"pane":{"pane_id":"tp2","tab_id":"tt","workspace_id":"w1"}}}"#,
-        );
-        runner.push_stdout(r#"{"result":{"type":"ok"}}"#);
-        runner.push_stdout(r#"{"result":{"type":"ok"}}"#);
-        runner.push_stdout(r#"{"result":{"type":"ok"}}"#);
+        runner.push_failure("no such entrypoint");
 
-        let launch = launch_layout_tab_picker(
+        let error = launch_overlay_picker(
             "herdr",
             &mut runner,
             &PaneId::new("p2"),
-            Path::new("/bin/herdr-pluck"),
-            Vec::new(),
-        )
-        .unwrap();
-
-        let zoom_call = vec![
-            "pane".to_string(),
-            "zoom".to_string(),
-            "tp2".to_string(),
-            "--on".to_string(),
-        ];
-        let zoom_index = runner
-            .calls
-            .iter()
-            .position(|call| call == &zoom_call)
-            .expect("expected temp target pane to be zoomed");
-        let first_run_index = runner
-            .calls
-            .iter()
-            .position(|call| call.get(1).is_some_and(|arg| arg == "run"))
-            .expect("expected pane run commands");
-        assert!(zoom_index < first_run_index);
-
-        let snapshot = crate::herdr::snapshot::read_snapshot_file(&launch.snapshot_file.path)
-            .expect("snapshot should be readable");
-        assert_eq!(snapshot.source.target_content_width, 97);
-        assert_eq!(snapshot.source.target_content_height, 38);
-        let _ = std::fs::remove_file(launch.snapshot_file.path);
-    }
-
-    #[test]
-    fn zoom_failure_cleans_up_session() {
-        let mut runner = FakeRunner::default();
-        runner.push_stdout(zoomed_layout_json());
-        runner.push_stdout("https://example.com\n");
-        runner.push_stdout(r#"{"result":{"tab":{"tab_id":"tt","workspace_id":"w1"},"root_pane":{"pane_id":"tp1","tab_id":"tt","workspace_id":"w1"}}}"#);
-        runner.push_stdout(
-            r#"{"result":{"pane":{"pane_id":"tp2","tab_id":"tt","workspace_id":"w1"}}}"#,
-        );
-        runner.push_failure("zoom failed");
-        runner.push_stdout(r#"{"result":{"type":"ok"}}"#);
-        runner.push_stdout(r#"{"result":{"type":"ok"}}"#);
-
-        let error = launch_layout_tab_picker(
-            "herdr",
-            &mut runner,
-            &PaneId::new("p2"),
-            Path::new("/bin/herdr-pluck"),
+            "rmarganti.herdr-pluck",
             Vec::new(),
         )
         .unwrap_err();
 
-        assert!(error.to_string().contains("zoom failed"));
-        assert!(runner
-            .calls
+        assert!(error.to_string().contains("no such entrypoint"));
+        let env_arg = runner.calls[2]
             .iter()
-            .any(|call| call == &vec!["tab".to_string(), "focus".to_string(), "t1".to_string(),]));
-        assert!(runner
-            .calls
-            .iter()
-            .any(|call| call == &vec!["tab".to_string(), "close".to_string(), "tt".to_string(),]));
-    }
-
-    #[test]
-    fn failed_launch_cleanup_removes_snapshot_file() {
-        let path =
-            std::env::temp_dir().join(format!("herdr-pluck-cleanup-test-{}", std::process::id()));
-        std::fs::write(&path, b"snapshot").unwrap();
-        let snapshot_file = SnapshotFile { path: path.clone() };
-        let session = TempTabSession {
-            temp_tab_id: "tt".to_string(),
-            return_tab_id: "t1".to_string(),
-            return_pane_id: PaneId::new("p1"),
-        };
-        let mut runner = FakeRunner::default();
-        runner.push_stdout(r#"{"result":{"type":"ok"}}"#);
-        runner.push_stdout(r#"{"result":{"type":"ok"}}"#);
-
-        cleanup_failed_launch("herdr", &mut runner, &session, &snapshot_file);
-
-        assert!(!path.exists());
+            .find(|arg| arg.starts_with("HERDR_PLUCK_SNAPSHOT_PATH="))
+            .expect("open call should pass the snapshot path env");
+        let path = env_arg.split_once('=').unwrap().1;
+        assert!(!std::path::Path::new(path).exists());
     }
 }

--- a/src/herdr/layout.rs
+++ b/src/herdr/layout.rs
@@ -1,8 +1,5 @@
-use crate::model::{
-    LayoutNode, LayoutRecreationPlan, PaneId, Rect, SourceGeometrySnapshot, SourcePaneGeometry,
-    SplitDirection,
-};
-use anyhow::{anyhow, Context, Result};
+use crate::model::{PaneId, Rect, SourceGeometrySnapshot, SplitDirection};
+use anyhow::{Context, Result};
 use serde::Deserialize;
 
 /// Top-level Herdr CLI response wrapper for `pane layout`.
@@ -57,45 +54,7 @@ pub fn parse_layout_snapshot(bytes: &[u8]) -> Result<LayoutSnapshot> {
     Ok(envelope.result.layout)
 }
 
-/// Builds a pure replay plan from Herdr layout data without running Herdr commands.
-pub fn derive_layout_recreation_plan(
-    layout: &LayoutSnapshot,
-    target: &PaneId,
-) -> Result<LayoutRecreationPlan> {
-    if !layout.panes.iter().any(|pane| pane.pane_id == target.0) {
-        return Err(anyhow!("target pane {target} was not present in layout"));
-    }
-
-    let root = build_layout_node(layout.area, &layout.panes, &layout.splits)?;
-    Ok(LayoutRecreationPlan {
-        root,
-        target_source_pane_id: target.clone(),
-    })
-}
-
-/// Returns source-pane geometry records with content rects derived from Herdr borders/gutter.
-pub fn derive_source_pane_geometries(layout: &LayoutSnapshot) -> Vec<SourcePaneGeometry> {
-    let border_inset = u16::from(layout.panes.len() > 1);
-    layout
-        .panes
-        .iter()
-        .map(|pane| {
-            let content_rect = pane
-                .rect
-                .inset(border_inset)
-                .reserve_right_gutter(u16::from(pane.rect.inset(border_inset).width > 1));
-            SourcePaneGeometry {
-                pane_id: PaneId::new(pane.pane_id.clone()),
-                outer_rect: pane.rect,
-                content_rect,
-                content_width: content_rect.width,
-                content_height: content_rect.height,
-            }
-        })
-        .collect()
-}
-
-/// Derives legacy source-pane content geometry from Herdr-global pre-overlay layout coordinates.
+/// Derives source-pane content geometry from Herdr-global pre-overlay layout coordinates.
 pub fn derive_source_geometry(layout: &LayoutSnapshot, target: &PaneId) -> SourceGeometrySnapshot {
     let pane_count = layout.panes.len();
     let target_pane = layout
@@ -131,122 +90,6 @@ pub fn derive_source_geometry(layout: &LayoutSnapshot, target: &PaneId) -> Sourc
     }
 }
 
-fn build_layout_node(
-    region: Rect,
-    panes: &[LayoutPane],
-    splits: &[LayoutSplit],
-) -> Result<LayoutNode> {
-    let panes_in_region: Vec<&LayoutPane> = panes
-        .iter()
-        .filter(|pane| rect_contains_rect(region, pane.rect))
-        .collect();
-
-    if panes_in_region.is_empty() {
-        return Err(anyhow!(
-            "layout region x={} y={} w={} h={} contains no panes",
-            region.x,
-            region.y,
-            region.width,
-            region.height
-        ));
-    }
-
-    if panes_in_region.len() == 1 {
-        let pane = panes_in_region[0];
-        return Ok(LayoutNode::Pane {
-            source_pane_id: PaneId::new(pane.pane_id.clone()),
-            rect: pane.rect,
-        });
-    }
-
-    let split = splits
-        .iter()
-        .find(|split| split.rect == region)
-        .ok_or_else(|| {
-            anyhow!(
-                "no split describes layout region with {} panes",
-                panes_in_region.len()
-            )
-        })?;
-
-    let (first_region, second_region) = partition_region(region, split, &panes_in_region)?;
-    Ok(LayoutNode::Split {
-        direction: split.direction,
-        ratio: split.ratio,
-        first: Box::new(build_layout_node(first_region, panes, splits)?),
-        second: Box::new(build_layout_node(second_region, panes, splits)?),
-        rect: region,
-    })
-}
-
-fn partition_region(
-    region: Rect,
-    split: &LayoutSplit,
-    panes: &[&LayoutPane],
-) -> Result<(Rect, Rect)> {
-    let mut first = Vec::new();
-    let mut second = Vec::new();
-    let split_at = match split.direction {
-        SplitDirection::Right => region.x + ((region.width as f32 * split.ratio).round() as u16),
-        SplitDirection::Down => region.y + ((region.height as f32 * split.ratio).round() as u16),
-    };
-
-    for pane in panes {
-        match split.direction {
-            SplitDirection::Right if pane.rect.x.saturating_add(pane.rect.width) <= split_at => {
-                first.push(pane.rect)
-            }
-            SplitDirection::Right if pane.rect.x >= split_at => second.push(pane.rect),
-            SplitDirection::Down if pane.rect.y.saturating_add(pane.rect.height) <= split_at => {
-                first.push(pane.rect)
-            }
-            SplitDirection::Down if pane.rect.y >= split_at => second.push(pane.rect),
-            _ => {
-                return Err(anyhow!(
-                    "pane rect x={} y={} w={} h={} crosses split boundary {}",
-                    pane.rect.x,
-                    pane.rect.y,
-                    pane.rect.width,
-                    pane.rect.height,
-                    split_at
-                ))
-            }
-        }
-    }
-
-    let first = bounding_rect(&first).ok_or_else(|| anyhow!("split first child has no panes"))?;
-    let second =
-        bounding_rect(&second).ok_or_else(|| anyhow!("split second child has no panes"))?;
-    Ok((first, second))
-}
-
-fn rect_contains_rect(outer: Rect, inner: Rect) -> bool {
-    inner.x >= outer.x
-        && inner.y >= outer.y
-        && inner.x.saturating_add(inner.width) <= outer.x.saturating_add(outer.width)
-        && inner.y.saturating_add(inner.height) <= outer.y.saturating_add(outer.height)
-}
-
-fn bounding_rect(rects: &[Rect]) -> Option<Rect> {
-    rects.first()?;
-    let min_x = rects.iter().map(|rect| rect.x).min()?;
-    let min_y = rects.iter().map(|rect| rect.y).min()?;
-    let max_x = rects
-        .iter()
-        .map(|rect| rect.x.saturating_add(rect.width))
-        .max()?;
-    let max_y = rects
-        .iter()
-        .map(|rect| rect.y.saturating_add(rect.height))
-        .max()?;
-    Some(Rect::new(
-        min_x,
-        min_y,
-        max_x.saturating_sub(min_x),
-        max_y.saturating_sub(min_y),
-    ))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -272,116 +115,48 @@ mod tests {
     }
 
     #[test]
-    fn derives_single_pane_layout_plan_without_splits() {
+    fn single_pane_geometry_has_no_border_inset() {
         let layout = layout(vec![pane("p1", Rect::new(0, 0, 100, 40), true)], vec![]);
-        let plan = derive_layout_recreation_plan(&layout, &PaneId::new("p1")).unwrap();
-        assert_eq!(
-            plan.root,
-            LayoutNode::Pane {
-                source_pane_id: PaneId::new("p1"),
-                rect: Rect::new(0, 0, 100, 40)
-            }
-        );
+
+        let geometry = derive_source_geometry(&layout, &PaneId::new("p1"));
+
+        assert_eq!(geometry.source_outer_rect, Rect::new(0, 0, 100, 40));
+        assert_eq!(geometry.source_content_rect, Rect::new(0, 0, 99, 40));
     }
 
     #[test]
-    fn derives_uneven_right_split_layout_plan() {
+    fn multi_pane_geometry_insets_borders_and_gutter() {
         let layout = layout(
             vec![
-                pane("p1", Rect::new(0, 0, 20, 40), false),
-                pane("p2", Rect::new(20, 0, 80, 40), true),
+                pane("p1", Rect::new(0, 0, 40, 40), false),
+                pane("p2", Rect::new(40, 0, 60, 40), true),
             ],
             vec![LayoutSplit {
                 direction: SplitDirection::Right,
-                ratio: 0.2,
+                ratio: 0.4,
                 rect: Rect::new(0, 0, 100, 40),
             }],
         );
-        let plan = derive_layout_recreation_plan(&layout, &PaneId::new("p2")).unwrap();
-        assert!(matches!(
-            plan.root,
-            LayoutNode::Split {
-                direction: SplitDirection::Right,
-                ..
-            }
-        ));
+
+        let geometry = derive_source_geometry(&layout, &PaneId::new("p2"));
+
+        assert_eq!(geometry.source_outer_rect, Rect::new(40, 0, 60, 40));
+        assert_eq!(geometry.source_content_rect, Rect::new(41, 1, 57, 38));
     }
 
     #[test]
-    fn derives_uneven_down_split_layout_plan() {
-        let layout = layout(
+    fn zoomed_focused_target_uses_full_area() {
+        let mut layout = layout(
             vec![
-                pane("p1", Rect::new(0, 0, 100, 8), false),
-                pane("p2", Rect::new(0, 8, 100, 32), true),
+                pane("p1", Rect::new(0, 0, 40, 40), false),
+                pane("p2", Rect::new(40, 0, 60, 40), true),
             ],
-            vec![LayoutSplit {
-                direction: SplitDirection::Down,
-                ratio: 0.2,
-                rect: Rect::new(0, 0, 100, 40),
-            }],
+            vec![],
         );
-        let plan = derive_layout_recreation_plan(&layout, &PaneId::new("p1")).unwrap();
-        assert!(matches!(
-            plan.root,
-            LayoutNode::Split {
-                direction: SplitDirection::Down,
-                ..
-            }
-        ));
-    }
+        layout.zoomed = true;
 
-    #[test]
-    fn derives_nested_two_by_two_layout() {
-        let layout = layout(
-            vec![
-                pane("tl", Rect::new(0, 0, 50, 20), false),
-                pane("bl", Rect::new(0, 20, 50, 20), false),
-                pane("tr", Rect::new(50, 0, 50, 20), false),
-                pane("br", Rect::new(50, 20, 50, 20), true),
-            ],
-            vec![
-                LayoutSplit {
-                    direction: SplitDirection::Right,
-                    ratio: 0.5,
-                    rect: Rect::new(0, 0, 100, 40),
-                },
-                LayoutSplit {
-                    direction: SplitDirection::Down,
-                    ratio: 0.5,
-                    rect: Rect::new(0, 0, 50, 40),
-                },
-                LayoutSplit {
-                    direction: SplitDirection::Down,
-                    ratio: 0.5,
-                    rect: Rect::new(50, 0, 50, 40),
-                },
-            ],
-        );
-        let plan = derive_layout_recreation_plan(&layout, &PaneId::new("br")).unwrap();
-        assert_eq!(plan.target_source_pane_id, PaneId::new("br"));
-    }
+        let geometry = derive_source_geometry(&layout, &PaneId::new("p2"));
 
-    #[test]
-    fn target_must_be_present() {
-        let layout = layout(vec![pane("p1", Rect::new(0, 0, 100, 40), true)], vec![]);
-        let error = derive_layout_recreation_plan(&layout, &PaneId::new("missing")).unwrap_err();
-        assert!(error.to_string().contains("target pane missing"));
-    }
-
-    #[test]
-    fn pane_crossing_split_boundary_fails_clearly() {
-        let layout = layout(
-            vec![
-                pane("p1", Rect::new(0, 0, 60, 40), true),
-                pane("p2", Rect::new(60, 0, 40, 40), false),
-            ],
-            vec![LayoutSplit {
-                direction: SplitDirection::Right,
-                ratio: 0.5,
-                rect: Rect::new(0, 0, 100, 40),
-            }],
-        );
-        let error = derive_layout_recreation_plan(&layout, &PaneId::new("p1")).unwrap_err();
-        assert!(error.to_string().contains("crosses split boundary"));
+        assert_eq!(geometry.source_outer_rect, Rect::new(0, 0, 100, 40));
     }
 }

--- a/src/herdr/mod.rs
+++ b/src/herdr/mod.rs
@@ -4,20 +4,19 @@ pub mod executor;
 pub mod layout;
 pub mod snapshot;
 
-use crate::config::resolve_pattern_specs;
+use crate::config::{resolve_pattern_specs, PLUGIN_ID};
 use crate::herdr::commands::ProcessCommandRunner;
 use crate::herdr::context::HerdrContext;
-use crate::herdr::executor::{cleanup_session, launch_layout_tab_picker, run_snapshot_picker};
+use crate::herdr::executor::{launch_overlay_picker, run_snapshot_picker};
 use crate::herdr::snapshot::{read_snapshot_file, remove_snapshot_file};
 use crate::model::PaneId;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::path::Path;
 
-pub use context::{HERDR_PLUCK_SNAPSHOT_JSON, HERDR_PLUCK_TARGET_PANE_ID};
-pub use layout::{derive_layout_recreation_plan, parse_layout_snapshot};
-pub use snapshot::{SnapshotTransport, SnapshotTransportConstraints};
+pub use context::HERDR_PLUCK_SNAPSHOT_PATH;
+pub use layout::parse_layout_snapshot;
 
-/// Narrow production adapter for Herdr layout-tab launch and picker cleanup.
+/// Narrow production adapter for Herdr overlay-pane launch and picker mode.
 #[derive(Debug, Clone)]
 pub struct HerdrAdapter {
     context: HerdrContext,
@@ -38,33 +37,29 @@ impl HerdrAdapter {
         self.context.target_pane()
     }
 
-    /// Launches the production layout-tab picker for the requested source pane.
-    pub fn open_layout_tab_picker(&self, target: &PaneId) -> Result<()> {
-        let binary_path = std::env::current_exe().context("failed to locate herdr-pluck binary")?;
+    /// Launches the production overlay picker for the requested source pane.
+    pub fn open_overlay_picker(&self, target: &PaneId) -> Result<()> {
         let mut runner = ProcessCommandRunner;
         let focused_pane_cwd = self.context.focused_pane_cwd();
         let custom_patterns = resolve_pattern_specs(focused_pane_cwd.as_deref());
-        launch_layout_tab_picker(
+        let plugin_id = self.context.plugin_id.as_deref().unwrap_or(PLUGIN_ID);
+        launch_overlay_picker(
             &self.context.herdr_bin,
             &mut runner,
             target,
-            &binary_path,
+            plugin_id,
             custom_patterns,
         )?;
         Ok(())
     }
 
-    /// Runs picker placeholder from a snapshot file and then performs session cleanup.
+    /// Runs picker mode from a snapshot file; the overlay closes when this process exits.
     pub fn run_picker_from_snapshot(&self, snapshot_path: &Path) -> Result<()> {
         let snapshot = read_snapshot_file(snapshot_path)?;
         let picker_result = run_snapshot_picker(&snapshot);
-        let mut runner = ProcessCommandRunner;
-        let cleanup_result =
-            cleanup_session(&self.context.herdr_bin, &mut runner, &snapshot.session);
         let remove_result = remove_snapshot_file(snapshot_path);
 
         picker_result?;
-        cleanup_result?;
         remove_result?;
         Ok(())
     }

--- a/src/herdr/snapshot.rs
+++ b/src/herdr/snapshot.rs
@@ -1,7 +1,6 @@
-use crate::herdr::layout::{derive_source_geometry, derive_source_pane_geometries, LayoutSnapshot};
+use crate::herdr::layout::{derive_source_geometry, LayoutSnapshot};
 use crate::model::{
-    PaneId, PaneTextCaptureMode, PatternSpec, PickerSnapshot, SourcePaneSnapshot, TempTabSession,
-    VisibleViewport,
+    PaneId, PaneTextCaptureMode, PatternSpec, PickerSnapshot, SourcePaneSnapshot, VisibleViewport,
 };
 use anyhow::{Context, Result};
 use std::fs;
@@ -11,63 +10,18 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 static SNAPSHOT_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// Picker snapshot transport selected by the Herdr launcher after considering payload constraints.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SnapshotTransport {
-    EnvJson,
-    TempFile,
-}
-
-/// Constraints used to choose how a picker snapshot is passed to the temporary pane process.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SnapshotTransportConstraints {
-    pub payload_bytes: usize,
-    pub command_involves_shell: bool,
-    pub supports_direct_env: bool,
-}
-
-impl SnapshotTransportConstraints {
-    pub const SAFE_ENV_JSON_BYTES: usize = 16 * 1024;
-
-    /// Chooses the simplest safe transport, reserving temp files for large or shell-fragile payloads.
-    pub fn choose_transport(self) -> SnapshotTransport {
-        if self.supports_direct_env
-            && !self.command_involves_shell
-            && self.payload_bytes <= Self::SAFE_ENV_JSON_BYTES
-        {
-            SnapshotTransport::EnvJson
-        } else {
-            SnapshotTransport::TempFile
-        }
-    }
-}
-
-/// Filesystem-backed picker snapshot owned by the temporary Herdr session.
+/// Filesystem-backed picker snapshot handed to the overlay pane process.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SnapshotFile {
     pub path: PathBuf,
 }
 
-/// Chooses the currently supported picker snapshot transport for `pane run` launches.
-pub fn choose_picker_snapshot_transport(snapshot: &PickerSnapshot) -> Result<SnapshotTransport> {
-    let payload_bytes = serde_json::to_vec(snapshot)
-        .context("failed to serialize picker snapshot for transport choice")?
-        .len();
-    Ok(SnapshotTransportConstraints {
-        payload_bytes,
-        command_involves_shell: true,
-        supports_direct_env: false,
-    }
-    .choose_transport())
-}
-
-/// Builds the immutable picker snapshot from source layout, text, and cleanup session ids.
+/// Builds the immutable picker snapshot from source layout and captured text.
 pub fn build_source_snapshot(
     layout: &LayoutSnapshot,
     target: &PaneId,
     logical_lines: Vec<String>,
     visible_viewport: Option<VisibleViewport>,
-    session: TempTabSession,
     custom_patterns: Vec<PatternSpec>,
 ) -> Result<PickerSnapshot> {
     let source_tab_id = layout
@@ -78,29 +32,24 @@ pub fn build_source_snapshot(
         .workspace_id
         .clone()
         .context("pane layout did not include workspace id")?;
-    let source_panes = derive_source_pane_geometries(layout);
-    let target_geometry = derive_source_geometry(layout, target);
-    let (target_content_width, target_content_height) = (
-        target_geometry.source_content_rect.width,
-        target_geometry.source_content_rect.height,
-    );
-    if !source_panes.iter().any(|pane| pane.pane_id == *target) {
-        anyhow::bail!("target pane geometry missing from source layout");
+    if !layout.panes.iter().any(|pane| pane.pane_id == target.0) {
+        anyhow::bail!("target pane {target} missing from source layout");
     }
+    let target_geometry = derive_source_geometry(layout, target);
 
     Ok(PickerSnapshot {
         source: SourcePaneSnapshot {
             target_pane_id: target.clone(),
             source_tab_id,
             workspace_id,
-            source_panes,
-            target_content_width,
-            target_content_height,
+            tab_area: layout.area,
+            target_content_rect: target_geometry.source_content_rect,
+            target_content_width: target_geometry.source_content_rect.width,
+            target_content_height: target_geometry.source_content_rect.height,
             logical_lines,
             visible_viewport,
             capture_mode: PaneTextCaptureMode::ExactVisibleUnwrapped,
         },
-        session,
         custom_patterns,
     })
 }
@@ -128,25 +77,6 @@ pub fn remove_snapshot_file(path: &Path) -> Result<()> {
     }
 }
 
-/// Shell-quotes one argument for `pane run`, which submits a command string to the pane shell.
-pub fn shell_quote(text: &str) -> String {
-    format!("'{}'", text.replace('\'', "'\\''"))
-}
-
-/// Builds the command string submitted to the temporary picker pane.
-pub fn picker_command(binary_path: &Path, snapshot_path: &Path) -> String {
-    format!(
-        "{} pick --snapshot {}",
-        shell_quote(&binary_path.display().to_string()),
-        shell_quote(&snapshot_path.display().to_string())
-    )
-}
-
-/// Quiet long-running command for non-target panes in the temporary layout tab.
-pub fn inert_pane_command() -> &'static str {
-    "printf '\\033[2J\\033[H'; sleep 86400"
-}
-
 fn unique_snapshot_path() -> PathBuf {
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -162,28 +92,7 @@ fn unique_snapshot_path() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{Rect, SourcePaneGeometry};
-
-    #[test]
-    fn snapshot_transport_uses_temp_file_for_shell_commands() {
-        let constraints = SnapshotTransportConstraints {
-            payload_bytes: 512,
-            command_involves_shell: true,
-            supports_direct_env: true,
-        };
-
-        assert_eq!(constraints.choose_transport(), SnapshotTransport::TempFile);
-    }
-
-    #[test]
-    fn picker_snapshot_transport_is_connected_to_pane_run_constraints() {
-        let snapshot = test_snapshot();
-
-        assert_eq!(
-            choose_picker_snapshot_transport(&snapshot).unwrap(),
-            SnapshotTransport::TempFile
-        );
-    }
+    use crate::model::Rect;
 
     #[test]
     fn snapshot_file_round_trips() {
@@ -200,37 +109,15 @@ mod tests {
                 target_pane_id: PaneId::new("p1"),
                 source_tab_id: "t1".to_string(),
                 workspace_id: "w1".to_string(),
-                source_panes: vec![SourcePaneGeometry {
-                    pane_id: PaneId::new("p1"),
-                    outer_rect: Rect::new(0, 0, 80, 24),
-                    content_rect: Rect::new(0, 0, 79, 24),
-                    content_width: 79,
-                    content_height: 24,
-                }],
+                tab_area: Rect::new(0, 0, 80, 24),
+                target_content_rect: Rect::new(0, 0, 79, 24),
                 target_content_width: 79,
                 target_content_height: 24,
                 logical_lines: vec!["https://example.com".to_string()],
                 visible_viewport: None,
                 capture_mode: PaneTextCaptureMode::RecentUnwrappedBottomApproximation,
             },
-            session: TempTabSession {
-                temp_tab_id: "t2".to_string(),
-                return_tab_id: "t1".to_string(),
-                return_pane_id: PaneId::new("p1"),
-            },
             custom_patterns: Vec::new(),
         }
-    }
-
-    #[test]
-    fn picker_command_quotes_paths() {
-        let command = picker_command(
-            Path::new("/tmp/herdr pluck/bin"),
-            Path::new("/tmp/a'b.json"),
-        );
-        assert_eq!(
-            command,
-            "'/tmp/herdr pluck/bin' pick --snapshot '/tmp/a'\\''b.json'"
-        );
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -101,23 +101,16 @@ pub enum PaneTextCaptureMode {
     VisibleWrapped,
 }
 
-/// One source pane's Herdr-global geometry captured before creating a temporary layout tab.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SourcePaneGeometry {
-    pub pane_id: PaneId,
-    pub outer_rect: Rect,
-    pub content_rect: Rect,
-    pub content_width: u16,
-    pub content_height: u16,
-}
-
-/// Immutable source tab state needed to launch and render a layout-tab picker.
+/// Immutable source pane state needed to render an overlay picker in place.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SourcePaneSnapshot {
     pub target_pane_id: PaneId,
     pub source_tab_id: String,
     pub workspace_id: String,
-    pub source_panes: Vec<SourcePaneGeometry>,
+    /// Full tab area the overlay pane covers, in Herdr-global coordinates.
+    pub tab_area: Rect,
+    /// Target pane content rect in Herdr-global coordinates (full area when zoomed).
+    pub target_content_rect: Rect,
     pub target_content_width: u16,
     pub target_content_height: u16,
     pub logical_lines: Vec<String>,
@@ -144,14 +137,6 @@ pub struct LogicalLineVisualSegment {
     pub col_end: usize,
 }
 
-/// Temporary layout-tab session ids required for explicit cleanup and focus restoration.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TempTabSession {
-    pub temp_tab_id: String,
-    pub return_tab_id: String,
-    pub return_pane_id: PaneId,
-}
-
 /// Serializable regex pattern config resolved before the picker pane starts.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PatternSpec {
@@ -164,49 +149,16 @@ pub struct PatternSpec {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PickerSnapshot {
     pub source: SourcePaneSnapshot,
-    pub session: TempTabSession,
     #[serde(default)]
     pub custom_patterns: Vec<PatternSpec>,
 }
 
-/// Direction of a Herdr binary pane split as exposed by layout snapshots and replay commands.
+/// Direction of a Herdr binary pane split as exposed by layout snapshots.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SplitDirection {
     Right,
     Down,
-}
-
-impl SplitDirection {
-    pub fn as_cli_arg(self) -> &'static str {
-        match self {
-            Self::Right => "right",
-            Self::Down => "down",
-        }
-    }
-}
-
-/// Binary Herdr layout tree with source pane ids preserved at leaves.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum LayoutNode {
-    Pane {
-        source_pane_id: PaneId,
-        rect: Rect,
-    },
-    Split {
-        direction: SplitDirection,
-        ratio: f32,
-        first: Box<LayoutNode>,
-        second: Box<LayoutNode>,
-        rect: Rect,
-    },
-}
-
-/// Replayable layout plan plus the source pane that must receive the picker.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct LayoutRecreationPlan {
-    pub root: LayoutNode,
-    pub target_source_pane_id: PaneId,
 }
 
 /// Unwrapped logical pane text lines and dimensions at the time of picker activation.

--- a/src/picker/render.rs
+++ b/src/picker/render.rs
@@ -1,6 +1,8 @@
 use crate::config::compile_pattern_specs;
 use crate::hints::{assign_hints, HintAssignments};
-use crate::model::{PickerOutcome, PickerSnapshot, RenderLine, RenderSpan, RenderStyle};
+use crate::model::{
+    PickerOutcome, PickerSnapshot, Rect, RenderLine, RenderSpan, RenderStyle, SourcePaneSnapshot,
+};
 use crate::patterns::find_matches;
 use crate::renderer::{render_inline_hints, render_visible_inline_hints, terminal};
 use anyhow::{Context, Result};
@@ -26,6 +28,33 @@ pub struct ReadonlyPickerView {
     pub lines: Vec<RenderLine>,
     pub match_count: usize,
     pub hint_count: usize,
+}
+
+/// Maps the source pane's content rect into overlay-local coordinates.
+///
+/// Assumes the overlay pane covers the source tab area minus symmetric chrome
+/// (borders/title), then clamps so the content never spills past the overlay.
+pub fn place_content_in_overlay(
+    source: &SourcePaneSnapshot,
+    overlay_cols: u16,
+    overlay_rows: u16,
+) -> Rect {
+    let inset_x = source.tab_area.width.saturating_sub(overlay_cols) / 2;
+    let inset_y = source.tab_area.height.saturating_sub(overlay_rows) / 2;
+    let content = source.target_content_rect.relative_to(source.tab_area);
+
+    let width = source.target_content_width.min(overlay_cols);
+    let height = source.target_content_height.min(overlay_rows);
+    let x = content
+        .x
+        .saturating_sub(inset_x)
+        .min(overlay_cols.saturating_sub(width));
+    let y = content
+        .y
+        .saturating_sub(inset_y)
+        .min(overlay_rows.saturating_sub(height));
+
+    Rect::new(x, y, width, height)
 }
 
 /// Builds the production picker view from captured pane text.
@@ -154,7 +183,7 @@ fn fit_to_width(text: &str, width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{PaneId, PaneTextCaptureMode, SourcePaneSnapshot, TempTabSession};
+    use crate::model::{PaneId, PaneTextCaptureMode, SourcePaneSnapshot};
 
     fn snapshot(lines: Vec<&str>, width: u16, height: u16) -> PickerSnapshot {
         PickerSnapshot {
@@ -162,20 +191,60 @@ mod tests {
                 target_pane_id: PaneId::new("p1"),
                 source_tab_id: "t1".to_string(),
                 workspace_id: "w1".to_string(),
-                source_panes: Vec::new(),
+                tab_area: Rect::new(0, 0, width, height),
+                target_content_rect: Rect::new(0, 0, width, height),
                 target_content_width: width,
                 target_content_height: height,
                 logical_lines: lines.into_iter().map(str::to_string).collect(),
                 visible_viewport: None,
                 capture_mode: PaneTextCaptureMode::RecentUnwrappedBottomApproximation,
             },
-            session: TempTabSession {
-                temp_tab_id: "t2".to_string(),
-                return_tab_id: "t1".to_string(),
-                return_pane_id: PaneId::new("p1"),
-            },
             custom_patterns: Vec::new(),
         }
+    }
+
+    fn geometry_snapshot(tab_area: Rect, content: Rect) -> SourcePaneSnapshot {
+        SourcePaneSnapshot {
+            target_pane_id: PaneId::new("p1"),
+            source_tab_id: "t1".to_string(),
+            workspace_id: "w1".to_string(),
+            tab_area,
+            target_content_rect: content,
+            target_content_width: content.width,
+            target_content_height: content.height,
+            logical_lines: Vec::new(),
+            visible_viewport: None,
+            capture_mode: PaneTextCaptureMode::ExactVisibleUnwrapped,
+        }
+    }
+
+    #[test]
+    fn placement_offsets_content_by_overlay_chrome_inset() {
+        // Tab area 100x40 at (26,1); overlay tty is 98x38 → symmetric inset of 1.
+        let source = geometry_snapshot(Rect::new(26, 1, 100, 40), Rect::new(31, 3, 60, 20));
+
+        let placement = place_content_in_overlay(&source, 98, 38);
+
+        assert_eq!(placement, Rect::new(4, 1, 60, 20));
+    }
+
+    #[test]
+    fn placement_clamps_content_to_overlay_bounds() {
+        // Content as wide as the tab area but overlay is smaller: clip and pin to origin.
+        let source = geometry_snapshot(Rect::new(0, 0, 100, 40), Rect::new(0, 0, 100, 40));
+
+        let placement = place_content_in_overlay(&source, 98, 38);
+
+        assert_eq!(placement, Rect::new(0, 0, 98, 38));
+    }
+
+    #[test]
+    fn placement_shifts_bottom_right_content_inside_overlay() {
+        let source = geometry_snapshot(Rect::new(0, 0, 100, 40), Rect::new(60, 30, 40, 10));
+
+        let placement = place_content_in_overlay(&source, 98, 38);
+
+        assert_eq!(placement, Rect::new(58, 28, 40, 10));
     }
 
     #[test]

--- a/src/picker/session.rs
+++ b/src/picker/session.rs
@@ -1,10 +1,10 @@
 use crate::clipboard::{Clipboard, SystemClipboard};
-use crate::model::{PickerOutcome, PickerSnapshot, RenderLine, RenderSpan, RenderStyle};
+use crate::model::{PickerOutcome, PickerSnapshot, Rect, RenderLine, RenderSpan, RenderStyle};
 use crate::picker::copy::copy_selected_text;
 use crate::picker::input::{
     CrosstermInputSource, InputDecision, InputSource, InputState, PickerInputEvent, RawModeGuard,
 };
-use crate::picker::render::build_picker_view;
+use crate::picker::render::{build_picker_view, place_content_in_overlay};
 use crate::renderer::terminal;
 use anyhow::{anyhow, Result};
 use std::io::{self, Write};
@@ -14,12 +14,18 @@ pub fn run_picker(snapshot: &PickerSnapshot) -> Result<PickerOutcome> {
     let mut stdout = io::stdout();
     let mut input = CrosstermInputSource;
     let clipboard = SystemClipboard;
+    let (overlay_cols, overlay_rows) = crossterm::terminal::size().unwrap_or((
+        snapshot.source.target_content_width,
+        snapshot.source.target_content_height,
+    ));
+    let placement = place_content_in_overlay(&snapshot.source, overlay_cols, overlay_rows);
     let _raw_mode = RawModeGuard::enable()?;
-    run_picker_with(snapshot, &mut input, &clipboard, &mut stdout)
+    run_picker_with(snapshot, placement, &mut input, &clipboard, &mut stdout)
 }
 
 pub(crate) fn run_picker_with<I, C, W>(
     snapshot: &PickerSnapshot,
+    placement: Rect,
     input: &mut I,
     clipboard: &C,
     output: &mut W,
@@ -30,7 +36,7 @@ where
     W: Write,
 {
     let view = build_picker_view(snapshot);
-    terminal::emit_render_lines(output, &view.lines)?;
+    terminal::emit_render_lines_at(output, &view.lines, placement)?;
     output.flush()?;
 
     let Some(width) = view.assignments.width() else {
@@ -90,7 +96,7 @@ fn emit_copy_failure(output: &mut impl Write, text: &str, error: &anyhow::Error)
 mod tests {
     use super::*;
     use crate::clipboard::{ClipboardError, CopySuccess};
-    use crate::model::{PaneId, PaneTextCaptureMode, SourcePaneSnapshot, TempTabSession};
+    use crate::model::{PaneId, PaneTextCaptureMode, SourcePaneSnapshot};
     use std::cell::RefCell;
 
     struct FakeInput {
@@ -138,17 +144,13 @@ mod tests {
                 target_pane_id: PaneId::new("p1"),
                 source_tab_id: "t1".to_string(),
                 workspace_id: "w1".to_string(),
-                source_panes: Vec::new(),
+                tab_area: Rect::new(0, 0, width, height),
+                target_content_rect: Rect::new(0, 0, width, height),
                 target_content_width: width,
                 target_content_height: height,
                 logical_lines: lines.into_iter().map(str::to_string).collect(),
                 visible_viewport: None,
                 capture_mode: PaneTextCaptureMode::RecentUnwrappedBottomApproximation,
-            },
-            session: TempTabSession {
-                temp_tab_id: "t2".to_string(),
-                return_tab_id: "t1".to_string(),
-                return_pane_id: PaneId::new("p1"),
             },
             custom_patterns: Vec::new(),
         }
@@ -162,6 +164,7 @@ mod tests {
 
         let outcome = run_picker_with(
             &snapshot(vec!["open https://example.com/path"], 40, 1),
+            Rect::new(0, 0, 80, 24),
             &mut input,
             &clipboard,
             &mut output,
@@ -192,6 +195,7 @@ mod tests {
                 40,
                 2,
             ),
+            Rect::new(0, 0, 80, 24),
             &mut input,
             &clipboard,
             &mut output,
@@ -218,6 +222,7 @@ mod tests {
 
         let outcome = run_picker_with(
             &snapshot(vec!["open https://example.com/path"], 40, 1),
+            Rect::new(0, 0, 80, 24),
             &mut input,
             &clipboard,
             &mut output,
@@ -237,6 +242,7 @@ mod tests {
 
             let outcome = run_picker_with(
                 &snapshot(vec!["open https://example.com/path"], 40, 1),
+                Rect::new(0, 0, 80, 24),
                 &mut input,
                 &clipboard,
                 &mut output,
@@ -256,6 +262,7 @@ mod tests {
 
         let outcome = run_picker_with(
             &snapshot(vec!["open https://example.com/path"], 40, 1),
+            Rect::new(0, 0, 80, 24),
             &mut input,
             &clipboard,
             &mut output,
@@ -278,6 +285,7 @@ mod tests {
 
         let error = run_picker_with(
             &snapshot(vec!["open https://example.com/path"], 40, 1),
+            Rect::new(0, 0, 80, 24),
             &mut input,
             &clipboard,
             &mut output,
@@ -298,6 +306,7 @@ mod tests {
 
         let outcome = run_picker_with(
             &snapshot(vec!["plain text only"], 30, 3),
+            Rect::new(0, 0, 80, 24),
             &mut input,
             &clipboard,
             &mut output,

--- a/src/renderer/terminal.rs
+++ b/src/renderer/terminal.rs
@@ -1,4 +1,4 @@
-use crate::model::{RenderLine, RenderStyle};
+use crate::model::{Rect, RenderLine, RenderSpan, RenderStyle};
 use anyhow::Result;
 use crossterm::{
     cursor::MoveTo,
@@ -9,6 +9,7 @@ use crossterm::{
     terminal::{Clear, ClearType},
 };
 use std::io::Write;
+use unicode_width::UnicodeWidthStr;
 
 /// Emits abstract picker render lines to a terminal writer using v1 styling.
 pub fn emit_render_lines(writer: &mut impl Write, lines: &[RenderLine]) -> Result<()> {
@@ -26,6 +27,59 @@ pub fn emit_render_lines(writer: &mut impl Write, lines: &[RenderLine]) -> Resul
 
     queue!(writer, ResetColor, SetAttribute(Attribute::Reset))?;
     Ok(())
+}
+
+/// Emits render lines positioned at `placement` inside the overlay pane,
+/// clipping to the placement size so nothing wraps past the overlay edge.
+pub fn emit_render_lines_at(
+    writer: &mut impl Write,
+    lines: &[RenderLine],
+    placement: Rect,
+) -> Result<()> {
+    queue!(writer, Clear(ClearType::All))?;
+
+    for (row, line) in lines.iter().take(placement.height as usize).enumerate() {
+        queue!(writer, MoveTo(placement.x, placement.y + row as u16))?;
+        for span in clip_spans(&line.spans, placement.width as usize) {
+            queue_style(writer, span.style)?;
+            queue!(writer, Print(&span.text))?;
+        }
+    }
+
+    queue!(writer, ResetColor, SetAttribute(Attribute::Reset))?;
+    Ok(())
+}
+
+/// Clips styled spans to a maximum display width, splitting mid-span if needed.
+fn clip_spans(spans: &[RenderSpan], max_width: usize) -> Vec<RenderSpan> {
+    let mut clipped = Vec::new();
+    let mut used = 0;
+    for span in spans {
+        let span_width = span.text.width();
+        if used + span_width <= max_width {
+            clipped.push(span.clone());
+            used += span_width;
+            continue;
+        }
+
+        let mut text = String::new();
+        for ch in span.text.chars() {
+            let char_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+            if used + char_width > max_width {
+                break;
+            }
+            text.push(ch);
+            used += char_width;
+        }
+        if !text.is_empty() {
+            clipped.push(RenderSpan {
+                text,
+                style: span.style,
+            });
+        }
+        break;
+    }
+    clipped
 }
 
 fn queue_style(writer: &mut impl Write, style: RenderStyle) -> Result<()> {
@@ -86,6 +140,66 @@ mod tests {
         assert!(output.contains("\u{1b}[38;5;0m"));
         assert!(output.contains("\u{1b}[48;5;14m"));
         assert!(output.contains("\u{1b}[38;5;11m"));
+    }
+
+    #[test]
+    fn positioned_emission_moves_to_placement_origin_per_row() {
+        let lines = vec![
+            RenderLine {
+                spans: vec![RenderSpan {
+                    text: "one".to_string(),
+                    style: RenderStyle::Unmatched,
+                }],
+            },
+            RenderLine {
+                spans: vec![RenderSpan {
+                    text: "two".to_string(),
+                    style: RenderStyle::Match,
+                }],
+            },
+        ];
+        let mut output = Vec::new();
+
+        emit_render_lines_at(&mut output, &lines, Rect::new(4, 2, 10, 5)).unwrap();
+        let output = String::from_utf8(output).unwrap();
+
+        assert!(output.contains("\u{1b}[3;5H"));
+        assert!(output.contains("\u{1b}[4;5H"));
+        assert!(output.contains("one"));
+        assert!(output.contains("two"));
+    }
+
+    #[test]
+    fn positioned_emission_clips_rows_and_columns_to_placement() {
+        let lines = vec![
+            RenderLine {
+                spans: vec![
+                    RenderSpan {
+                        text: "abc".to_string(),
+                        style: RenderStyle::Unmatched,
+                    },
+                    RenderSpan {
+                        text: "defgh".to_string(),
+                        style: RenderStyle::Match,
+                    },
+                ],
+            },
+            RenderLine {
+                spans: vec![RenderSpan {
+                    text: "hidden".to_string(),
+                    style: RenderStyle::Unmatched,
+                }],
+            },
+        ];
+        let mut output = Vec::new();
+
+        emit_render_lines_at(&mut output, &lines, Rect::new(0, 0, 5, 1)).unwrap();
+        let output = String::from_utf8(output).unwrap();
+
+        assert!(output.contains("abc"));
+        assert!(output.contains("de"));
+        assert!(!output.contains("def"));
+        assert!(!output.contains("hidden"));
     }
 
     #[test]


### PR DESCRIPTION
**FULL DISCLOSURE:**
I am not a Rust developer and I let Fable 5 do the work. I did not check the resulting code. It works for me and gives the "real tmux-fingers experience". Feel free to close this PR.

---

### Problem

Invoking the pluck action opened a temporary tab that mirrored the source layout: tab create --focus, one pane split per source pane, per-pane pane run, optional zoom replication, and on exit tab focus + tab close. Every step is a separate Herdr CLI round trip that mutates visible window state, so the picker appeared with noticeable flicker and lag (two visible tab switches per invocation).

### Solution

Use Herdr's native plugin overlay panes (available since 0.7), the same mechanism tmux-fingers approximates with its swap-pane trick:

- herdr-plugin.toml declares a [[panes]] picker entrypoint with placement = "overlay".
- open shrinks to three CLI calls: pane layout, pane read --source visible, and a single plugin pane open --placement overlay, passing the snapshot file path via --env HERDR_PLUCK_SNAPSHOT_PATH.
- The overlay's lifecycle is server-managed: it closes when the picker process exits (copy, Escape, Ctrl-C, or focus loss) and Herdr restores focus to the source pane itself — no explicit cleanup.
- The picker positions its rendering inside the overlay at the target pane's content rect (mapped from tab-area coordinates assuming symmetric overlay chrome, clamped and clipped to the overlay size), so hints appear where the text is on screen.

### Removed

The entire temp-tab machinery: layout recreation tree and split replay (LayoutNode, LayoutRecreationPlan), TempTabSession and session cleanup, the shell-quoted pane run snapshot transport (SnapshotTransport, shell_quote, picker_command, inert_pane_command), and the now-unused tab create/pane split/pane run/pane zoom/tab focus/tab close CLI wrappers. Net: 438 insertions, 999 deletions.

### Verification

- cargo fmt, cargo test (110 passed), cargo clippy — all clean.
- Live end-to-end against a running Herdr 0.7.3: overlay opens in place with hint letters destructively overlaid on URL/SHA/IP tokens, rows aligned 1:1 with the source pane; selecting a hint copies the full token to the system clipboard and closes the overlay; Escape cancels without touching the clipboard and focus returns to the source pane.
